### PR TITLE
Add meal planning and grocery management support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *.so
 *.dylib
 bin
+paprika-3-mcp
 
 # Test binary, built with `go test -c`
 *.test
@@ -24,3 +25,9 @@ go.work.sum
 
 # env file
 .env
+
+# AI assistant rules and personal configuration files
+WARP.md
+CLAUDE.md
+.cursor/
+.cursorrules

--- a/FABLE_REVIEW.md
+++ b/FABLE_REVIEW.md
@@ -1,0 +1,117 @@
+# FABLE_REVIEW.md — paprika-3-mcp fork review
+
+*Researched and written 2026-06-09. Reviewer: Claude (Fable 5), acting as senior Go engineer.*
+
+## Summary
+
+This repo is `bsitkoff/paprika-3-mcp` (branch `add-meal-grocery-features`), a fork of `soggycactus/paprika-3-mcp` — a Go MCP server for Paprika 3. The fork adds meal-planning and grocery tools on top of upstream's recipe tools, implemented via **V1 endpoints with Basic Auth** (`POST /api/v1/sync/meals/`, `/api/v1/sync/groceries/`). Meal creation now fails because **those V1 endpoints return 401** — the V1-Basic-Auth approach is itself the thing that broke.
+
+State of the upstream: **frozen and effectively orphaned**. Upstream `main` is still at `c8de3bf` (Apr 13, 2025) — exactly the commit this fork is based on. The maintainer opened issue #13 *"New maintainer(s) needed"* (May 28, 2026). The only upstream branch with newer work is `lucas/fixes` (PR #5, Dec 2025, unmerged).
+
+Severity of divergence: **low in git terms** (fork = upstream main + 2 commits + 1 uncommitted change; upstream hasn't moved at all), but **high in community terms** — the fork's feature work was picked up, improved, fixed, and tested by other forks, and the current best version of this codebase lives in an open upstream PR, not here.
+
+**Bottom line: the fix already exists.** Upstream PR #11 (JoshTerAvest, Mar 30, 2026) switches meal/grocery writes to the V2 bulk endpoints with Bearer auth and is confirmed working by two independent users. Recommendation: adopt that branch rather than patch this one (details below).
+
+## Research findings
+
+### Upstream (`soggycactus/paprika-3-mcp`)
+
+- **Commits:** none since `c8de3bf` (Apr 2025). No development has happened on `main` since this fork was created. 17 forks, 11 open issues/PRs.
+- **Issue #13** (May 2026): maintainer (soggycactus) is seeking new maintainers. JoshTerAvest has volunteered (comment on PR #11).
+- **Branch `lucas/fixes` / PR #5** (soggycactus, Dec 2025, open): upgrades `mark3labs/mcp-go` v0.18.0 → v0.43.2, replaces raw `req.Params.Arguments["x"].(string)` type assertions with `req.RequireString(...)` and `mcp.NewToolResultError(...)`. Fixes the nil-interface panic in issue #4. Does **not** touch meals/groceries (upstream never had them).
+
+### Has the V1/V2 meal API issue been addressed? Yes — PR #11
+
+The history is a relay race that started from this very fork:
+
+1. **PR #3** (bsitkoff — this fork, Oct 2025, open): "Add meal planning and grocery management support" — the V1 Basic Auth implementation that is now broken.
+2. **PR #10** (ksletmoe, Mar 24, 2026, closed): *explicitly "Based on PR #3"* — kept the features, added a `PaprikaClient` interface, 22 mock-based unit tests, `postV2` helper, multi-grocery-list support, and fixed two latent bugs (date-filter boundary, missing soft-delete filtering). Still used V1 for writes.
+3. **In PR #10's discussion, JoshTerAvest reported the V1 endpoints returning 401** with *both* Basic Auth and Bearer token, and found the fix: the **V2 bulk array endpoints**. ksletmoe tested it: *"I tested this out this evening while meal planning and your branch all works great"*, then closed #10 in favor of:
+4. **PR #11** (JoshTerAvest, Mar 30, 2026, **open** — head `JoshTerAvest:main`): "Fix meal and grocery sync: use V2 bulk endpoints". The confirmed-working write path is:
+   - `POST https://www.paprikaapp.com/api/v2/sync/meals/` and `POST https://www.paprikaapp.com/api/v2/sync/groceries/`
+   - body: **gzipped JSON array** (even for one item) in a multipart form field `data`
+   - auth: **Bearer token** (same as recipe endpoints) — *not* Basic Auth
+   - host: **`www.paprikaapp.com`** (the missing `www.` may have contributed to the 401s)
+   - deletes remain soft (`deleted: true` in the same array POST)
+
+PR #11 also bundles: shared `postV2` helper (removes ~400 lines of duplicated gzip/multipart code), a retry transport (429/5xx with `Retry-After` support), the `Categories: nil → []` fix for issue #7 ("Value cannot be null. Parameter name: collection."), `list_recipes` / `delete_recipe` / `list_grocery_lists` tools, concurrent recipe fetching for search, and the PR #10 test suite. It's unmerged only because upstream is unmaintained.
+
+### Other forks
+
+Of 17 forks, the only ones with meaningful development are the chain above: `ksletmoe/paprika-3-mcp` (PR #10) and `JoshTerAvest/paprika-3-mcp` (PR #11 + PR #12, last pushed May 26, 2026). The rest are stale copies of upstream or this fork's own (`bsitkoff`).
+
+### Is "meals require V1 since Sept 2024" still true? The premise is garbled — here's the corrected history.
+
+A full sweep of community documentation (the canonical mattdsteele gist + its comment thread, the kappari reverse-engineering project, the Home Assistant integration thread, several open-source clients) establishes:
+
+- **What actually broke in September 2024 was the V2 *login* endpoint, not meal sync.** `POST /api/v2/account/login` started rejecting password-only logins with "Unrecognized client" (~Sept 19, 2024, multi-source). Around the same time Paprika introduced **aggressive rate limiting / temporary IP bans** for heavy callers (~hundreds of calls/min). Previously issued tokens kept working.
+- **There is no public evidence a V2 meals write ever worked before 2026** — the "V2 meal endpoints broke" framing is unverifiable. The official client uses `/api/v2/sync/menuitems/` for the separate *Menus* feature; for the meal *planner*, the only public worked example (gist commenter dahoo, Jul 2025) is `POST https://www.paprikaapp.com/api/v1/sync/meals/` with a gzipped JSON array in multipart field `data` — exactly the seven fields this fork sends (`uid, recipe_uid, date, type, name, deleted, order_flag`).
+- **A token from `POST /api/v1/account/login/` works as a Bearer token on V2 sync endpoints** (multi-source, freshest data point May 31, 2026 via kappari). This is exactly what this codebase's `login()` already does — so the Bearer-on-V2 write path in PR #11 is consistent with the documented auth model.
+- **No breaking API changes were found in 2025-2026.** V1 Basic Auth writes were still being reported working as late as Jul 2025 (dahoo) and the V1-login/V2-sync pattern as late as May 2026 (kappari).
+
+So the honest reconciliation: community docs say V1 Basic Auth meal writes *should* still work (and did for PR #10's author — JoshTerAvest allowed his 401s "might be account-specific"), yet this fork fails for its owner and JoshTerAvest's V1 attempts failed with both auth schemes, while the V2-bulk path was verified working by two people against this codebase in March 2026. One concrete difference from every *working* example: this fork posts to **`paprikaapp.com`** while both dahoo's working V1 example and PR #11's working V2 code use **`www.paprikaapp.com`**. (A cross-host redirect would make Go's `net/http` strip the `Authorization` header — but a credential-less probe today shows no redirect on either host, so that can't be confirmed from outside.) Another possibility is the Sept-2024 rate limiter: this fork's resource loop re-fetches every recipe every minute, which on a large collection approaches the reported ban threshold, and Paprika's blocks are IP-scoped.
+
+The recommendation is unaffected: PR #11's path is the one most recently verified against this exact codebase, and it's consistent with the documented auth model. The first verification step after adopting it must be an end-to-end test against *this* account — and if that somehow fails, the documented fallback is dahoo's V1 recipe with the `www.` host.
+
+Key sources (full list and confidence levels in the research agent's notes):
+- Canonical API gist + comments (Sept-2024 timeline, meal POST format): https://gist.github.com/mattdsteele/7386ec363badfdeaad05a418b9a1f30a
+- kappari — actively maintained reverse-engineering of the V2 API/auth, updated May 2026: https://github.com/johnwbyrd/kappari
+- Home Assistant thread (independent confirmation of the login break + V2 reads): https://community.home-assistant.io/t/paprika-recipe-app-integration-whats-for-dinner-tonight/707405
+- joshstrange/paprika-api (V1 Basic Auth GET catalog): https://github.com/joshstrange/paprika-api
+
+## Decision: rebase vs. fix in place
+
+**Recommendation: adopt PR #11's branch (`JoshTerAvest:main`) and re-apply this fork's one unique improvement on top.**
+
+Reasoning:
+
+- A literal "rebase from upstream" is moot — upstream `main` has not moved since the fork point. There is nothing to rebase onto.
+- The real choice is (a) port the endpoint/auth fix into this fork's code, or (b) take PR #11's branch wholesale. Option (a) is only ~20 lines of semantic change, **but** it would be spread across four near-identical ~100-line functions, and it would re-derive by hand what PR #11 already has tested and reviewed. Option (b) gets the identical fix **plus** 22 unit tests, the deduplicated `postV2` helper, retry logic, the issue-#7 recipe fix, and bug fixes to date filtering and soft-delete handling — and loses nothing, because PR #11 descends from this fork's own PR #3 feature set.
+- The only local work not in PR #11 is the uncommitted `cmd/paprika-3-mcp/main.go` change (env-var fallback for `--username`/`--password` — worth keeping; it's a one-commit cherry-pick).
+- Deliberately deferred: PR #5's mcp-go v0.43 upgrade. It's good hygiene but orthogonal to the breakage, and it churns every tool handler. Do it as a follow-up, not bundled with the fix.
+
+## Implementation plan
+
+1. **Preserve local work:** commit the pending `main.go` change on `add-meal-grocery-features`
+   (`git add cmd/paprika-3-mcp/main.go && git commit -m "Add env var fallback for credentials"`).
+2. **Fetch the fixed branch:**
+   `git remote add josh https://github.com/JoshTerAvest/paprika-3-mcp.git && git fetch josh`
+3. **Create the adoption branch:** `git checkout -b adopt-v2-bulk-fix josh/main`
+4. **Cherry-pick the env-var commit** from step 1 (`git cherry-pick <sha>`; conflict risk is near zero — PR #11 doesn't touch `main.go` beyond flag help text; if both touched it, keep both changes).
+5. **Apply PR #8's login fix** (closed-unmerged upstream, but correct): in `internal/paprika/client.go` `login()`, replace
+   `body := fmt.Sprintf("email=%s&password=%s", username, password)` with
+   `body := url.Values{"email": {username}, "password": {password}}.Encode()` (+ `net/url` import). Optionally bring over its `login_test.go`.
+6. **Check PR #12** (Categories nil normalization) — PR #11's diff already contains the `SaveRecipe` normalization; verify after checkout and skip #12 if present.
+7. **Update the docs that encode the wrong API model:** `CLAUDE.md` and `WARP.md` both teach "V1 (Basic Auth) required for meal/grocery writes" as fact. Rewrite those sections to the V2-bulk truth, or a future session will confidently "fix" the code backwards.
+8. **Verify:**
+   - `go build ./... && go vet ./... && go test ./...` (PR #11's unit tests run without credentials)
+   - `PAPRIKA_USERNAME=… PAPRIKA_PASSWORD=… go test ./internal/paprika -v` (integration; mutates the real account)
+   - End-to-end: `make install`, restart the MCP server, `add_meal_to_plan` for a test date, confirm via `list_meal_plan` and in the Paprika app, then `remove_meal_from_plan`.
+   - **Contingency:** if the V2-bulk write fails against this account too, fall back to the community-documented V1 form with the corrected host — `POST https://www.paprikaapp.com/api/v1/sync/meals/`, Basic Auth, same gzipped-array payload (the dahoo/Jul-2025 recipe). The delta from current code is then just the `www.` prefix.
+9. **Housekeeping:** push to the `bsitkoff` fork; comment on upstream PR #3 pointing to PR #11 as its successor (optionally close #3); consider responding to issue #13 — the people who fixed this are actively offering to maintain.
+
+## Go code quality
+
+The original upstream core (client.go recipe paths, server scaffolding) is serviceable hobby-grade Go. The meal/grocery additions in this fork have the hallmarks of LLM-assisted bolt-on code. Specific winces, current code:
+
+- **Massive duplication:** `SaveMealPlan`, `DeleteMealPlan`, `SaveGroceryItem`, `DeleteGroceryItem` (`internal/paprika/client.go:643-1035`) are four copies of the same ~95-line gzip→multipart→POST→check sequence, differing only in URL and payload. `SaveRecipe` is a fifth variant. PR #11's `postV2(ctx, endpoint, v interface{})` collapses all of them.
+- **No-op code:** `if item.OrderFlag == 0 { item.OrderFlag = 0 }` (`client.go:845-847`).
+- **Broken error capture in goroutines:** `addResourcesConcurrently` (`internal/mcpserver/server.go:216-229`) declares `go func() (err error)` (a return value nobody receives) and registers `defer func(err error){...}(err)` — the deferred closure receives `err`'s value *at defer time*, which is always nil, so failures are silently swallowed. There's also no `WaitGroup`, so shutdown ordering is luck.
+- **Login encoding bug:** `login()` (`client.go:117`) builds the form body with `fmt.Sprintf` — a password containing `&`, `=`, `+`, or `%` corrupts the request. Fixed (with table-driven tests) in upstream PR #8.
+- **Hand-rolled bubble sorts** for date and aisle keys (`server.go:806-812`, `server.go:904-910`) where `sort.Strings(dates)` is one line.
+- **Date-boundary bug:** `list_meal_plan` compares `meal.Date` (`"YYYY-MM-DD HH:MM:SS"`) lexically against `end_date` (`"YYYY-MM-DD"`); `"2026-06-09 00:00:00" > "2026-06-09"`, so meals on the end date are excluded. (PR #10/#11 fix this.)
+- **Soft-deleted rows not filtered:** `listMealPlan` / `listGroceries` render items even when `Deleted: true`, so "removed" entries can reappear in tool output.
+- **N+1 serial fetch:** `searchRecipes` calls `GetRecipe` sequentially for every recipe in the account inside a 30s timeout; large collections will time out. (PR #11 fetches concurrently with a semaphore.)
+- **Stale framework + error convention:** `mcp-go v0.18.0` (current: v0.43.x). Handlers return Go errors for bad arguments (a *protocol* error to the client) instead of `mcp.NewToolResultError` (a *tool* error the model can react to). Upstream PR #5 shows the exact migration.
+- **Dead field:** `NewServerOptions.Paprika` (`server.go:20`) is never used — `NewServer` always constructs its own client.
+- **Testing:** the only test is one integration test that creates/deletes real recipes in a live account and requires credentials; nothing is unit-testable because `*paprika.Client` is concrete. PR #11's `PaprikaClient` interface + mock tests fix this.
+- Minor: hashing pre-sorts map keys before `json.Marshal`, which already sorts map keys — harmless but redundant; `notify()` is deferred with a context that may be near its deadline; stray double blank lines.
+
+## Additional findings
+
+- **Rate-limiter exposure:** since ~Sept 2024 Paprika temporarily IP-bans heavy callers (reported trigger: hundreds of calls/min; the official app makes 2-4 per session). This server's `updateResources` loop re-fetches **every recipe individually every minute**, and `search_recipes` re-fetches the whole collection per query. On a large recipe collection this flirts with the ban threshold — and a ban would also break the Paprika apps on the same network. `ListRecipes` already returns a per-recipe `hash`; cache by hash and skip unchanged recipes, and/or lengthen the refresh interval substantially.
+- **The docs are a footgun:** `CLAUDE.md` and `WARP.md` both assert the V1-Basic-Auth model ("V1 API … required for creating/updating meal plans") as established fact, citing the Kappari docs. Any agent or human following them will reintroduce the broken pattern. Updating them is part of the fix, not optional polish.
+- **Uncommitted work:** `cmd/paprika-3-mcp/main.go` has a good, unrelated improvement sitting uncommitted (env-var fallback + clearer error message). Commit it before any branch surgery.
+- **Maintenance opportunity:** upstream is explicitly seeking maintainers (issue #13) and JoshTerAvest has volunteered. This fork's author started the meal/grocery feature chain (PR #3 → #10 → #11); coordinating there (rather than continuing a private fork) would get the fix merged and released via the existing Homebrew tap.
+- **Module path:** the fork still declares `module github.com/soggycactus/paprika-3-mcp`. Fine while it's a faithful fork, but worth renaming if it's going to diverge long-term.
+- **Issue #7** ("Value cannot be null. Parameter name: collection.") affects this fork too: `create_paprika_recipe` doesn't set `Categories`, a nil slice marshals to `null`, and Paprika's .NET clients choke on it during sync. PR #11/#12 normalize `nil → []` inside `SaveRecipe`.

--- a/README.md
+++ b/README.md
@@ -19,10 +19,31 @@ See anything missing? Open an issue on this repo to request a feature!
 
 #### 🛠 **Tools**
 
-- `create_paprika_recipe`  
-  Allows Claude to save a new recipe to your Paprika app
-- `update_paprika_recipe`  
-  Allows Claude to modify an existing recipe
+**Recipe Management**
+- `create_paprika_recipe`
+  Create new recipes in your Paprika app
+- `update_paprika_recipe`
+  Modify existing recipes
+- `get_recipe`
+  Get full recipe details by UID
+- `search_recipes`
+  Search and list recipes from your collection
+
+**Meal Planning**
+- `list_meal_plan`
+  View your scheduled meals by date range
+- `add_meal_to_plan`
+  Add meals to your calendar (supports Breakfast, Lunch, Dinner)
+- `remove_meal_from_plan`
+  Remove meals from your plan
+
+**Grocery Management**
+- `list_groceries`
+  View your grocery/shopping list with purchase status
+- `add_grocery_item`
+  Add items to your shopping list
+- `remove_grocery_item`
+  Remove items from your shopping list
 
 ## ⚙️ Prerequisites
 

--- a/cmd/paprika-3-mcp/main.go
+++ b/cmd/paprika-3-mcp/main.go
@@ -29,8 +29,8 @@ func getLogFilePath() string {
 }
 
 func main() {
-	username := flag.String("username", "", "Paprika 3 username (email)")
-	password := flag.String("password", "", "Paprika 3 password")
+	username := flag.String("username", "", "Paprika 3 username (email). Falls back to $PAPRIKA_USERNAME.")
+	password := flag.String("password", "", "Paprika 3 password. Falls back to $PAPRIKA_PASSWORD.")
 	showVersion := flag.Bool("version", false, "Print version and exit")
 	flag.Parse()
 
@@ -39,8 +39,15 @@ func main() {
 		os.Exit(0)
 	}
 
+	if *username == "" {
+		*username = os.Getenv("PAPRIKA_USERNAME")
+	}
+	if *password == "" {
+		*password = os.Getenv("PAPRIKA_PASSWORD")
+	}
+
 	if *username == "" || *password == "" {
-		fmt.Fprintln(os.Stderr, "username and password are required")
+		fmt.Fprintln(os.Stderr, "username and password are required (set --username/--password flags or PAPRIKA_USERNAME/PAPRIKA_PASSWORD env vars)")
 		os.Exit(1)
 	}
 

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -2,7 +2,6 @@ package mcpserver
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -75,12 +74,6 @@ func (s *Server) Start() {
 		mcp.WithString("query", mcp.Description("Search term to find recipes (searches name, ingredients, and description). Leave empty to list all recipes."), mcp.DefaultString("")),
 		mcp.WithNumber("limit", mcp.Description("Maximum number of recipes to return"), mcp.DefaultNumber(10)),
 	)
-	exploreAPITool := mcp.NewTool("explore_paprika_api",
-		mcp.WithDescription("Explore Paprika API endpoints to find meal planning and grocery features"),
-	)
-	inspectMealTool := mcp.NewTool("inspect_meal_data",
-		mcp.WithDescription("Inspect the raw structure of existing meals to understand the API format"),
-	)
 	listMealPlanTool := mcp.NewTool("list_meal_plan",
 		mcp.WithDescription("List your meal plan from Paprika showing scheduled meals by date"),
 		mcp.WithString("start_date", mcp.Description("Start date in YYYY-MM-DD format (optional)"), mcp.DefaultString("")),
@@ -101,6 +94,22 @@ func (s *Server) Start() {
 		mcp.WithDescription("Remove a meal from your Paprika meal plan calendar"),
 		mcp.WithString("meal_uid", mcp.Description("UID of the meal to remove (get from list_meal_plan)"), mcp.Required()),
 	)
+	getRecipeTool := mcp.NewTool("get_recipe",
+		mcp.WithDescription("Get full recipe details by UID including ingredients, directions, prep time, and notes"),
+		mcp.WithString("uid", mcp.Description("UID of the recipe to get"), mcp.Required()),
+	)
+	addGroceryItemTool := mcp.NewTool("add_grocery_item",
+		mcp.WithDescription("Add an item to your Paprika grocery/shopping list"),
+		mcp.WithString("ingredient", mcp.Description("The ingredient/item name"), mcp.Required()),
+		mcp.WithString("aisle", mcp.Description("Store aisle where item is located (optional)"), mcp.DefaultString("")),
+		mcp.WithString("quantity", mcp.Description("Quantity needed (optional)"), mcp.DefaultString("")),
+		mcp.WithString("recipe", mcp.Description("Recipe this ingredient is for (optional)"), mcp.DefaultString("")),
+		mcp.WithString("instruction", mcp.Description("Special instructions (optional)"), mcp.DefaultString("")),
+	)
+	removeGroceryItemTool := mcp.NewTool("remove_grocery_item",
+		mcp.WithDescription("Remove an item from your Paprika grocery/shopping list"),
+		mcp.WithString("item_name", mcp.Description("Name of the item to remove (searches ingredient names)"), mcp.Required()),
+	)
 	s.server.AddTools(server.ServerTool{
 		Tool:    createRecipeTool,
 		Handler: s.createRecipe,
@@ -110,9 +119,6 @@ func (s *Server) Start() {
 	}, server.ServerTool{
 		Tool:    searchRecipesTool,
 		Handler: s.searchRecipes,
-	}, server.ServerTool{
-		Tool:    exploreAPITool,
-		Handler: s.exploreAPI,
 	}, server.ServerTool{
 		Tool:    listMealPlanTool,
 		Handler: s.listMealPlan,
@@ -126,8 +132,14 @@ func (s *Server) Start() {
 		Tool:    removeMealTool,
 		Handler: s.removeMealFromPlan,
 	}, server.ServerTool{
-		Tool:    inspectMealTool,
-		Handler: s.inspectMealData,
+		Tool:    getRecipeTool,
+		Handler: s.getRecipe,
+	}, server.ServerTool{
+		Tool:    addGroceryItemTool,
+		Handler: s.addGroceryItem,
+	}, server.ServerTool{
+		Tool:    removeGroceryItemTool,
+		Handler: s.removeGroceryItem,
 	})
 
 	if err := server.ServeStdio(s.server); err != nil {
@@ -359,60 +371,60 @@ func (s *Server) updateRecipe(ctx context.Context, req mcp.CallToolRequest) (*mc
 
 func (s *Server) searchRecipes(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	start := time.Now()
-	
+
 	// Get search query and limit
 	query := ""
 	if val, ok := req.Params.Arguments["query"].(string); ok {
 		query = strings.ToLower(strings.TrimSpace(val))
 	}
-	
+
 	limit := 10
 	if val, ok := req.Params.Arguments["limit"].(float64); ok {
 		limit = int(val)
 	}
-	
+
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
-	
+
 	// Get all recipes
 	recipeList, err := s.paprika3.ListRecipes(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list recipes: %w", err)
 	}
-	
+
 	// Fetch full recipe details and filter
 	var matchedRecipes []paprika.Recipe
 	for _, recipeInfo := range recipeList.Result {
 		if len(matchedRecipes) >= limit {
 			break
 		}
-		
+
 		recipe, err := s.paprika3.GetRecipe(ctx, recipeInfo.UID)
 		if err != nil {
 			s.logger.Error("failed to get recipe details", "uid", recipeInfo.UID, "error", err)
 			continue
 		}
-		
+
 		if recipe.InTrash {
 			continue
 		}
-		
+
 		// If no query, include all recipes
 		if query == "" {
 			matchedRecipes = append(matchedRecipes, *recipe)
 			continue
 		}
-		
+
 		// Search in recipe name, ingredients, and description
 		searchText := strings.ToLower(recipe.Name + " " + recipe.Ingredients + " " + recipe.Description)
 		if strings.Contains(searchText, query) {
 			matchedRecipes = append(matchedRecipes, *recipe)
 		}
 	}
-	
+
 	duration := time.Since(start)
 	s.logger.Info("Search completed", "query", query, "matches", len(matchedRecipes), "duration", duration)
-	
+
 	// Format results
 	var resultText strings.Builder
 	if query != "" {
@@ -420,7 +432,7 @@ func (s *Server) searchRecipes(ctx context.Context, req mcp.CallToolRequest) (*m
 	} else {
 		resultText.WriteString("# All Recipes\n\n")
 	}
-	
+
 	if len(matchedRecipes) == 0 {
 		if query != "" {
 			resultText.WriteString("No recipes found matching your search.\n")
@@ -429,7 +441,7 @@ func (s *Server) searchRecipes(ctx context.Context, req mcp.CallToolRequest) (*m
 		}
 	} else {
 		resultText.WriteString(fmt.Sprintf("Found %d recipe(s):\n\n", len(matchedRecipes)))
-		
+
 		for i, recipe := range matchedRecipes {
 			resultText.WriteString(fmt.Sprintf("%d. **%s**\n", i+1, recipe.Name))
 			if recipe.Description != "" {
@@ -455,13 +467,177 @@ func (s *Server) searchRecipes(ctx context.Context, req mcp.CallToolRequest) (*m
 			resultText.WriteString("\n")
 		}
 	}
-	
+
 	return mcp.NewToolResultText(resultText.String()), nil
+}
+
+func (s *Server) addGroceryItem(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	start := time.Now()
+
+	// Get required parameter
+	ingredient, ok := req.Params.Arguments["ingredient"].(string)
+	if !ok || ingredient == "" {
+		return nil, errors.New("ingredient is required")
+	}
+
+	// Get optional parameters
+	aisle := ""
+	if val, ok := req.Params.Arguments["aisle"].(string); ok {
+		aisle = strings.TrimSpace(val)
+	}
+	quantity := ""
+	if val, ok := req.Params.Arguments["quantity"].(string); ok {
+		quantity = strings.TrimSpace(val)
+	}
+	recipe := ""
+	if val, ok := req.Params.Arguments["recipe"].(string); ok {
+		recipe = strings.TrimSpace(val)
+	}
+	instruction := ""
+	if val, ok := req.Params.Arguments["instruction"].(string); ok {
+		instruction = strings.TrimSpace(val)
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	// Create grocery item
+	item := paprika.GroceryItem{
+		Ingredient:  ingredient,
+		Name:        ingredient, // Use ingredient name as display name
+		Aisle:       aisle,
+		Quantity:    quantity,
+		Recipe:      recipe,
+		Instruction: instruction,
+		Purchased:   false, // New items are not purchased
+		OrderFlag:   0,
+	}
+
+	// Save the grocery item
+	savedItem, err := s.paprika3.SaveGroceryItem(ctx, item)
+	if err != nil {
+		return nil, fmt.Errorf("failed to add grocery item: %w", err)
+	}
+
+	duration := time.Since(start)
+	s.logger.Info("Added grocery item", "ingredient", ingredient, "aisle", aisle, "duration", duration)
+
+	// Format result
+	var resultText strings.Builder
+	resultText.WriteString("# Grocery Item Added Successfully\n\n")
+	resultText.WriteString(fmt.Sprintf("Added **%s** to your grocery list\n\n", ingredient))
+	resultText.WriteString(fmt.Sprintf("- **Item**: %s\n", ingredient))
+	if quantity != "" {
+		resultText.WriteString(fmt.Sprintf("- **Quantity**: %s\n", quantity))
+	}
+	if aisle != "" {
+		resultText.WriteString(fmt.Sprintf("- **Aisle**: %s\n", aisle))
+	}
+	if recipe != "" {
+		resultText.WriteString(fmt.Sprintf("- **For Recipe**: %s\n", recipe))
+	}
+	if instruction != "" {
+		resultText.WriteString(fmt.Sprintf("- **Instructions**: %s\n", instruction))
+	}
+	resultText.WriteString(fmt.Sprintf("- **Item ID**: %s\n\n", savedItem.UID))
+	resultText.WriteString("The item has been added to your Paprika grocery list.\n")
+
+	return mcp.NewToolResultText(resultText.String()), nil
+}
+
+func (s *Server) removeGroceryItem(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	start := time.Now()
+
+	// Get item name parameter
+	itemName, ok := req.Params.Arguments["item_name"].(string)
+	if !ok || itemName == "" {
+		return nil, errors.New("item_name is required")
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	// Get current grocery list to find the item
+	groceryResp, err := s.paprika3.ListGroceries(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get grocery list: %w", err)
+	}
+
+	// Find matching items (case-insensitive search)
+	searchTerm := strings.ToLower(strings.TrimSpace(itemName))
+	var matchedItems []paprika.GroceryItem
+	for _, item := range groceryResp.Result {
+		if strings.Contains(strings.ToLower(item.Ingredient), searchTerm) ||
+			strings.Contains(strings.ToLower(item.Name), searchTerm) {
+			matchedItems = append(matchedItems, item)
+		}
+	}
+
+	if len(matchedItems) == 0 {
+		return mcp.NewToolResultText(fmt.Sprintf("# No Items Found\n\nNo grocery items found matching \"%s\". Use list_groceries to see your current list.", itemName)), nil
+	}
+
+	// If multiple matches, remove the first one but inform the user
+	itemToRemove := matchedItems[0]
+	err = s.paprika3.DeleteGroceryItem(ctx, itemToRemove.UID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to remove grocery item: %w", err)
+	}
+
+	duration := time.Since(start)
+	s.logger.Info("Removed grocery item", "ingredient", itemToRemove.Ingredient, "uid", itemToRemove.UID, "duration", duration)
+
+	// Format result
+	var resultText strings.Builder
+	resultText.WriteString("# Grocery Item Removed Successfully\n\n")
+	resultText.WriteString(fmt.Sprintf("Removed **%s** from your grocery list.\n\n", itemToRemove.Ingredient))
+
+	if len(matchedItems) > 1 {
+		resultText.WriteString(fmt.Sprintf("Note: Found %d items matching \"%s\". Removed the first match:\n", len(matchedItems), itemName))
+		for i, item := range matchedItems {
+			status := "❌ REMOVED"
+			if i > 0 {
+				status = "⚠️  Still in list"
+			}
+			resultText.WriteString(fmt.Sprintf("- %s %s", status, item.Ingredient))
+			if item.Quantity != "" {
+				resultText.WriteString(fmt.Sprintf(" (%s)", item.Quantity))
+			}
+			resultText.WriteString("\n")
+		}
+		resultText.WriteString("\nTo remove additional items, run the command again.\n")
+	} else {
+		resultText.WriteString("The item has been removed from your Paprika grocery list.\n")
+	}
+
+	return mcp.NewToolResultText(resultText.String()), nil
+}
+
+func (s *Server) getRecipe(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	start := time.Now()
+
+	uid, ok := req.Params.Arguments["uid"].(string)
+	if !ok || uid == "" {
+		return nil, errors.New("uid is required")
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	recipe, err := s.paprika3.GetRecipe(ctx, uid)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get recipe: %w", err)
+	}
+
+	duration := time.Since(start)
+	s.logger.Info("Retrieved recipe", "name", recipe.Name, "uid", recipe.UID, "duration", duration)
+
+	return mcp.NewToolResultText(recipe.ToMarkdown()), nil
 }
 
 func (s *Server) addMealToPlan(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	start := time.Now()
-	
+
 	// Get parameters
 	date, ok := req.Params.Arguments["date"].(string)
 	if !ok || date == "" {
@@ -471,24 +647,24 @@ func (s *Server) addMealToPlan(ctx context.Context, req mcp.CallToolRequest) (*m
 	if !ok || mealName == "" {
 		return nil, errors.New("meal_name is required")
 	}
-	
+
 	mealType := 2 // Default to dinner
 	if val, ok := req.Params.Arguments["meal_type"].(float64); ok {
 		mealType = int(val)
 	}
-	
+
 	recipeUID := ""
 	if val, ok := req.Params.Arguments["recipe_uid"].(string); ok {
 		recipeUID = strings.TrimSpace(val)
 	}
-	
+
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
-	
+
 	// Create meal plan entry with ALL required fields
 	// Format date correctly: "YYYY-MM-DD 00:00:00"
 	formattedDate := date + " 00:00:00"
-	
+
 	meal := paprika.MealPlan{
 		Date:      formattedDate,
 		Name:      mealName,
@@ -496,20 +672,20 @@ func (s *Server) addMealToPlan(ctx context.Context, req mcp.CallToolRequest) (*m
 		RecipeUID: recipeUID,
 		OrderFlag: 0,
 	}
-	
+
 	// Save the meal plan entry
 	savedMeal, err := s.paprika3.SaveMealPlan(ctx, meal)
 	if err != nil {
 		return nil, fmt.Errorf("failed to add meal to plan: %w", err)
 	}
-	
+
 	duration := time.Since(start)
 	s.logger.Info("Added meal to plan", "date", date, "meal", mealName, "type", mealType, "duration", duration)
-	
+
 	// Format result
 	var resultText strings.Builder
 	resultText.WriteString("# Meal Added Successfully\n\n")
-	
+
 	mealTypeStr := "Dinner"
 	switch mealType {
 	case 0:
@@ -519,7 +695,7 @@ func (s *Server) addMealToPlan(ctx context.Context, req mcp.CallToolRequest) (*m
 	case 2:
 		mealTypeStr = "Dinner"
 	}
-	
+
 	resultText.WriteString(fmt.Sprintf("Added **%s** as %s on %s\n\n", mealName, mealTypeStr, date))
 	resultText.WriteString(fmt.Sprintf("- **Date**: %s\n", date))
 	resultText.WriteString(fmt.Sprintf("- **Meal**: %s\n", mealName))
@@ -528,101 +704,46 @@ func (s *Server) addMealToPlan(ctx context.Context, req mcp.CallToolRequest) (*m
 		resultText.WriteString(fmt.Sprintf("- **Recipe ID**: %s\n", recipeUID))
 	}
 	resultText.WriteString(fmt.Sprintf("- **Meal ID**: %s\n\n", savedMeal.UID))
-	
+
 	resultText.WriteString("The meal has been added to your Paprika meal plan calendar.\n")
-	
+
 	return mcp.NewToolResultText(resultText.String()), nil
 }
 
 func (s *Server) removeMealFromPlan(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	start := time.Now()
-	
+
 	// Get meal UID parameter
 	mealUID, ok := req.Params.Arguments["meal_uid"].(string)
 	if !ok || mealUID == "" {
 		return nil, errors.New("meal_uid is required")
 	}
-	
+
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
-	
+
 	// Delete the meal plan entry
 	err := s.paprika3.DeleteMealPlan(ctx, mealUID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to remove meal from plan: %w", err)
 	}
-	
+
 	duration := time.Since(start)
 	s.logger.Info("Removed meal from plan", "meal_uid", mealUID, "duration", duration)
-	
+
 	// Format result
 	var resultText strings.Builder
 	resultText.WriteString("# Meal Removed Successfully\n\n")
 	resultText.WriteString(fmt.Sprintf("Removed meal with ID **%s** from your meal plan.\n\n", mealUID))
 	resultText.WriteString("The meal has been deleted from your Paprika meal plan calendar.\n")
-	
+
 	return mcp.NewToolResultText(resultText.String()), nil
 }
 
-func (s *Server) inspectMealData(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	start := time.Now()
-	
-	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
-	
-	// Get meal plan data
-	mealPlanResp, err := s.paprika3.ListMealPlan(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get meal plan: %w", err)
-	}
-	
-	duration := time.Since(start)
-	s.logger.Info("Retrieved meal plan for inspection", "count", len(mealPlanResp.Result), "duration", duration)
-	
-	// Format results with detailed inspection
-	var resultText strings.Builder
-	resultText.WriteString("# Meal Plan Data Inspection\n\n")
-	
-	if len(mealPlanResp.Result) == 0 {
-		resultText.WriteString("No meals found in your meal plan.\n")
-	} else {
-		resultText.WriteString(fmt.Sprintf("Found %d meal entries. Showing detailed structure:\n\n", len(mealPlanResp.Result)))
-		
-		// Show first few meals with full JSON structure
-		limit := 5
-		if len(mealPlanResp.Result) < limit {
-			limit = len(mealPlanResp.Result)
-		}
-		
-		for i, meal := range mealPlanResp.Result[:limit] {
-			resultText.WriteString(fmt.Sprintf("## Meal %d: %s\n", i+1, meal.Name))
-			resultText.WriteString(fmt.Sprintf("- **Date**: %s\n", meal.Date))
-			resultText.WriteString(fmt.Sprintf("- **UID**: %s\n", meal.UID))
-			resultText.WriteString(fmt.Sprintf("- **Recipe UID**: %s\n", meal.RecipeUID))
-			resultText.WriteString(fmt.Sprintf("- **Type**: %d\n", meal.Type))
-			resultText.WriteString(fmt.Sprintf("- **Order Flag**: %d\n", meal.OrderFlag))
-			resultText.WriteString(fmt.Sprintf("- **Deleted**: %t\n", meal.Deleted))
-			
-			// JSON representation
-			mealJSON, err := json.MarshalIndent(meal, "", "  ")
-			if err == nil {
-				resultText.WriteString("\n**Raw JSON Structure:**\n```json\n")
-				resultText.WriteString(string(mealJSON))
-				resultText.WriteString("\n```\n\n")
-			}
-		}
-		
-		if len(mealPlanResp.Result) > limit {
-			resultText.WriteString(fmt.Sprintf("... and %d more meals\n", len(mealPlanResp.Result)-limit))
-		}
-	}
-	
-	return mcp.NewToolResultText(resultText.String()), nil
-}
 
 func (s *Server) listMealPlan(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	start := time.Now()
-	
+
 	// Get date filters if provided
 	startDate := ""
 	if val, ok := req.Params.Arguments["start_date"].(string); ok {
@@ -632,16 +753,16 @@ func (s *Server) listMealPlan(ctx context.Context, req mcp.CallToolRequest) (*mc
 	if val, ok := req.Params.Arguments["end_date"].(string); ok {
 		endDate = strings.TrimSpace(val)
 	}
-	
+
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
-	
+
 	// Get meal plan from Paprika
 	mealPlanResp, err := s.paprika3.ListMealPlan(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get meal plan: %w", err)
 	}
-	
+
 	// Filter by date range if specified
 	var filteredMeals []paprika.MealPlan
 	for _, meal := range mealPlanResp.Result {
@@ -653,29 +774,29 @@ func (s *Server) listMealPlan(ctx context.Context, req mcp.CallToolRequest) (*mc
 		}
 		filteredMeals = append(filteredMeals, meal)
 	}
-	
+
 	duration := time.Since(start)
 	s.logger.Info("Retrieved meal plan", "total", len(mealPlanResp.Result), "filtered", len(filteredMeals), "duration", duration)
-	
+
 	// Format results
 	var resultText strings.Builder
 	resultText.WriteString("# Meal Plan\n\n")
-	
+
 	if startDate != "" || endDate != "" {
 		resultText.WriteString(fmt.Sprintf("Showing meals from %s to %s\n\n", startDate, endDate))
 	}
-	
+
 	if len(filteredMeals) == 0 {
 		resultText.WriteString("No meals found in the specified date range.\n")
 	} else {
 		resultText.WriteString(fmt.Sprintf("Found %d scheduled meal(s):\n\n", len(filteredMeals)))
-		
+
 		// Group by date
 		mealsByDate := make(map[string][]paprika.MealPlan)
 		for _, meal := range filteredMeals {
 			mealsByDate[meal.Date] = append(mealsByDate[meal.Date], meal)
 		}
-		
+
 		// Sort dates
 		dates := make([]string, 0, len(mealsByDate))
 		for date := range mealsByDate {
@@ -689,11 +810,11 @@ func (s *Server) listMealPlan(ctx context.Context, req mcp.CallToolRequest) (*mc
 				}
 			}
 		}
-		
+
 		for _, date := range dates {
 			meals := mealsByDate[date]
 			resultText.WriteString(fmt.Sprintf("## %s\n", date))
-			
+
 			for _, meal := range meals {
 				mealType := "Meal"
 				switch meal.Type {
@@ -704,7 +825,7 @@ func (s *Server) listMealPlan(ctx context.Context, req mcp.CallToolRequest) (*mc
 				case 0:
 					mealType = "Breakfast"
 				}
-				
+
 				resultText.WriteString(fmt.Sprintf("- **%s**: %s", mealType, meal.Name))
 				if meal.RecipeUID != "" {
 					resultText.WriteString(fmt.Sprintf(" (Recipe ID: %s)", meal.RecipeUID))
@@ -714,28 +835,28 @@ func (s *Server) listMealPlan(ctx context.Context, req mcp.CallToolRequest) (*mc
 			resultText.WriteString("\n")
 		}
 	}
-	
+
 	return mcp.NewToolResultText(resultText.String()), nil
 }
 
 func (s *Server) listGroceries(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	start := time.Now()
-	
+
 	// Get filter parameter
 	filter := "all"
 	if val, ok := req.Params.Arguments["filter"].(string); ok {
 		filter = strings.ToLower(strings.TrimSpace(val))
 	}
-	
+
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
-	
+
 	// Get groceries from Paprika
 	groceryResp, err := s.paprika3.ListGroceries(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get groceries: %w", err)
 	}
-	
+
 	// Filter items based on purchase status
 	var filteredItems []paprika.GroceryItem
 	for _, item := range groceryResp.Result {
@@ -752,19 +873,19 @@ func (s *Server) listGroceries(ctx context.Context, req mcp.CallToolRequest) (*m
 			filteredItems = append(filteredItems, item)
 		}
 	}
-	
+
 	duration := time.Since(start)
 	s.logger.Info("Retrieved groceries", "total", len(groceryResp.Result), "filtered", len(filteredItems), "filter", filter, "duration", duration)
-	
+
 	// Format results
 	var resultText strings.Builder
 	resultText.WriteString("# Grocery List\n\n")
-	
+
 	if len(filteredItems) == 0 {
 		resultText.WriteString("No grocery items found.\n")
 	} else {
 		resultText.WriteString(fmt.Sprintf("Found %d grocery item(s):\n\n", len(filteredItems)))
-		
+
 		// Group by aisle
 		itemsByAisle := make(map[string][]paprika.GroceryItem)
 		for _, item := range filteredItems {
@@ -774,7 +895,7 @@ func (s *Server) listGroceries(ctx context.Context, req mcp.CallToolRequest) (*m
 			}
 			itemsByAisle[aisle] = append(itemsByAisle[aisle], item)
 		}
-		
+
 		// Sort aisles alphabetically
 		aisles := make([]string, 0, len(itemsByAisle))
 		for aisle := range itemsByAisle {
@@ -787,17 +908,17 @@ func (s *Server) listGroceries(ctx context.Context, req mcp.CallToolRequest) (*m
 				}
 			}
 		}
-		
+
 		for _, aisle := range aisles {
 			items := itemsByAisle[aisle]
 			resultText.WriteString(fmt.Sprintf("## %s\n", aisle))
-			
+
 			for _, item := range items {
 				status := "☐"
 				if item.Purchased {
 					status = "☑"
 				}
-				
+
 				resultText.WriteString(fmt.Sprintf("%s **%s**", status, item.Ingredient))
 				if item.Quantity != "" {
 					resultText.WriteString(fmt.Sprintf(" (%s)", item.Quantity))
@@ -813,50 +934,7 @@ func (s *Server) listGroceries(ctx context.Context, req mcp.CallToolRequest) (*m
 			resultText.WriteString("\n")
 		}
 	}
-	
+
 	return mcp.NewToolResultText(resultText.String()), nil
 }
 
-func (s *Server) exploreAPI(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	start := time.Now()
-	
-	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
-	
-	// First try to get meal plan data
-	mealPlanResp, err := s.paprika3.ListMealPlan(ctx)
-	if err != nil {
-		s.logger.Error("failed to get meal plan data", "error", err)
-	}
-	
-	// Try to get grocery data
-	groceryResp, err := s.paprika3.ListGroceries(ctx)
-	if err != nil {
-		s.logger.Error("failed to get grocery data", "error", err)
-	}
-	
-	// Explore other API endpoints
-	err = s.paprika3.ExploreAPI(ctx)
-	if err != nil {
-		s.logger.Error("failed to explore API", "error", err)
-	}
-	
-	duration := time.Since(start)
-	s.logger.Info("API exploration completed", "duration", duration)
-	
-	var resultText strings.Builder
-	resultText.WriteString("# Paprika API Exploration Results\n\n")
-	resultText.WriteString("Explored various API endpoints to find meal planning and grocery features.\n\n")
-	
-	if mealPlanResp != nil {
-		resultText.WriteString(fmt.Sprintf("## Meal Plan API\nFound %d meal entries\n\n", len(mealPlanResp.Result)))
-	}
-	
-	if groceryResp != nil {
-		resultText.WriteString(fmt.Sprintf("## Grocery API\nFound %d grocery items\n\n", len(groceryResp.Result)))
-	}
-	
-	resultText.WriteString("Check the server logs for detailed exploration results of all attempted endpoints.\n")
-	
-	return mcp.NewToolResultText(resultText.String()), nil
-}

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -2,9 +2,11 @@ package mcpserver
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -68,12 +70,64 @@ func (s *Server) Start() {
 		mcp.WithString("cook_time", mcp.Description("The cook time for the recipe"), mcp.Required()),
 		mcp.WithString("difficulty", mcp.Description("The difficulty of the recipe"), mcp.Required()),
 	)
+	searchRecipesTool := mcp.NewTool("search_recipes",
+		mcp.WithDescription("Search and list recipes from your Paprika 3 collection"),
+		mcp.WithString("query", mcp.Description("Search term to find recipes (searches name, ingredients, and description). Leave empty to list all recipes."), mcp.DefaultString("")),
+		mcp.WithNumber("limit", mcp.Description("Maximum number of recipes to return"), mcp.DefaultNumber(10)),
+	)
+	exploreAPITool := mcp.NewTool("explore_paprika_api",
+		mcp.WithDescription("Explore Paprika API endpoints to find meal planning and grocery features"),
+	)
+	inspectMealTool := mcp.NewTool("inspect_meal_data",
+		mcp.WithDescription("Inspect the raw structure of existing meals to understand the API format"),
+	)
+	listMealPlanTool := mcp.NewTool("list_meal_plan",
+		mcp.WithDescription("List your meal plan from Paprika showing scheduled meals by date"),
+		mcp.WithString("start_date", mcp.Description("Start date in YYYY-MM-DD format (optional)"), mcp.DefaultString("")),
+		mcp.WithString("end_date", mcp.Description("End date in YYYY-MM-DD format (optional)"), mcp.DefaultString("")),
+	)
+	listGroceriesTool := mcp.NewTool("list_groceries",
+		mcp.WithDescription("List your current grocery/shopping list from Paprika"),
+		mcp.WithString("filter", mcp.Description("Filter by: 'purchased', 'unpurchased', or 'all'"), mcp.DefaultString("all")),
+	)
+	addMealTool := mcp.NewTool("add_meal_to_plan",
+		mcp.WithDescription("Add a meal to your Paprika meal plan calendar"),
+		mcp.WithString("date", mcp.Description("Date in YYYY-MM-DD format"), mcp.Required()),
+		mcp.WithString("meal_name", mcp.Description("Name of the meal"), mcp.Required()),
+		mcp.WithNumber("meal_type", mcp.Description("Meal type: 0=Breakfast, 1=Lunch, 2=Dinner"), mcp.DefaultNumber(2)),
+		mcp.WithString("recipe_uid", mcp.Description("UID of the recipe (optional - use search_recipes to find UIDs)"), mcp.DefaultString("")),
+	)
+	removeMealTool := mcp.NewTool("remove_meal_from_plan",
+		mcp.WithDescription("Remove a meal from your Paprika meal plan calendar"),
+		mcp.WithString("meal_uid", mcp.Description("UID of the meal to remove (get from list_meal_plan)"), mcp.Required()),
+	)
 	s.server.AddTools(server.ServerTool{
 		Tool:    createRecipeTool,
 		Handler: s.createRecipe,
 	}, server.ServerTool{
 		Tool:    updateRecipeTool,
 		Handler: s.updateRecipe,
+	}, server.ServerTool{
+		Tool:    searchRecipesTool,
+		Handler: s.searchRecipes,
+	}, server.ServerTool{
+		Tool:    exploreAPITool,
+		Handler: s.exploreAPI,
+	}, server.ServerTool{
+		Tool:    listMealPlanTool,
+		Handler: s.listMealPlan,
+	}, server.ServerTool{
+		Tool:    listGroceriesTool,
+		Handler: s.listGroceries,
+	}, server.ServerTool{
+		Tool:    addMealTool,
+		Handler: s.addMealToPlan,
+	}, server.ServerTool{
+		Tool:    removeMealTool,
+		Handler: s.removeMealFromPlan,
+	}, server.ServerTool{
+		Tool:    inspectMealTool,
+		Handler: s.inspectMealData,
 	})
 
 	if err := server.ServeStdio(s.server); err != nil {
@@ -178,12 +232,31 @@ func (s *Server) createRecipe(ctx context.Context, req mcp.CallToolRequest) (*mc
 	if !ok || len(directions) == 0 {
 		return nil, errors.New("directions are required")
 	}
-	servings := req.Params.Arguments["servings"].(string)
-	prepTime := req.Params.Arguments["prep_time"].(string)
-	cookTime := req.Params.Arguments["cook_time"].(string)
-	description := req.Params.Arguments["description"].(string)
-	notes := req.Params.Arguments["notes"].(string)
-	difficulty := req.Params.Arguments["difficulty"].(string)
+	// Handle optional string fields safely
+	servings := ""
+	if val, ok := req.Params.Arguments["servings"].(string); ok {
+		servings = val
+	}
+	prepTime := ""
+	if val, ok := req.Params.Arguments["prep_time"].(string); ok {
+		prepTime = val
+	}
+	cookTime := ""
+	if val, ok := req.Params.Arguments["cook_time"].(string); ok {
+		cookTime = val
+	}
+	description := ""
+	if val, ok := req.Params.Arguments["description"].(string); ok {
+		description = val
+	}
+	notes := ""
+	if val, ok := req.Params.Arguments["notes"].(string); ok {
+		notes = val
+	}
+	difficulty := ""
+	if val, ok := req.Params.Arguments["difficulty"].(string); ok {
+		difficulty = val
+	}
 
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
@@ -230,29 +303,30 @@ func (s *Server) updateRecipe(ctx context.Context, req mcp.CallToolRequest) (*mc
 	if !ok || len(directions) == 0 {
 		return nil, errors.New("directions are required")
 	}
-	description, ok := req.Params.Arguments["description"].(string)
-	if !ok {
-		return nil, errors.New("description is required")
+	// Handle optional string fields safely
+	description := ""
+	if val, ok := req.Params.Arguments["description"].(string); ok {
+		description = val
 	}
-	servings, ok := req.Params.Arguments["servings"].(string)
-	if !ok {
-		return nil, errors.New("servings is required")
+	servings := ""
+	if val, ok := req.Params.Arguments["servings"].(string); ok {
+		servings = val
 	}
-	prepTime, ok := req.Params.Arguments["prep_time"].(string)
-	if !ok {
-		return nil, errors.New("prepTime is required")
+	prepTime := ""
+	if val, ok := req.Params.Arguments["prep_time"].(string); ok {
+		prepTime = val
 	}
-	cookTime, ok := req.Params.Arguments["cook_time"].(string)
-	if !ok {
-		return nil, errors.New("cookTime is required")
+	cookTime := ""
+	if val, ok := req.Params.Arguments["cook_time"].(string); ok {
+		cookTime = val
 	}
-	notes, ok := req.Params.Arguments["notes"].(string)
-	if !ok {
-		return nil, errors.New("notes is required")
+	notes := ""
+	if val, ok := req.Params.Arguments["notes"].(string); ok {
+		notes = val
 	}
-	difficulty, ok := req.Params.Arguments["difficulty"].(string)
-	if !ok {
-		return nil, errors.New("difficulty is required")
+	difficulty := ""
+	if val, ok := req.Params.Arguments["difficulty"].(string); ok {
+		difficulty = val
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
@@ -281,4 +355,508 @@ func (s *Server) updateRecipe(ctx context.Context, req mcp.CallToolRequest) (*mc
 		MIMEType: "text/markdown",
 		Text:     recipe.ToMarkdown(),
 	}), nil
+}
+
+func (s *Server) searchRecipes(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	start := time.Now()
+	
+	// Get search query and limit
+	query := ""
+	if val, ok := req.Params.Arguments["query"].(string); ok {
+		query = strings.ToLower(strings.TrimSpace(val))
+	}
+	
+	limit := 10
+	if val, ok := req.Params.Arguments["limit"].(float64); ok {
+		limit = int(val)
+	}
+	
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	
+	// Get all recipes
+	recipeList, err := s.paprika3.ListRecipes(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list recipes: %w", err)
+	}
+	
+	// Fetch full recipe details and filter
+	var matchedRecipes []paprika.Recipe
+	for _, recipeInfo := range recipeList.Result {
+		if len(matchedRecipes) >= limit {
+			break
+		}
+		
+		recipe, err := s.paprika3.GetRecipe(ctx, recipeInfo.UID)
+		if err != nil {
+			s.logger.Error("failed to get recipe details", "uid", recipeInfo.UID, "error", err)
+			continue
+		}
+		
+		if recipe.InTrash {
+			continue
+		}
+		
+		// If no query, include all recipes
+		if query == "" {
+			matchedRecipes = append(matchedRecipes, *recipe)
+			continue
+		}
+		
+		// Search in recipe name, ingredients, and description
+		searchText := strings.ToLower(recipe.Name + " " + recipe.Ingredients + " " + recipe.Description)
+		if strings.Contains(searchText, query) {
+			matchedRecipes = append(matchedRecipes, *recipe)
+		}
+	}
+	
+	duration := time.Since(start)
+	s.logger.Info("Search completed", "query", query, "matches", len(matchedRecipes), "duration", duration)
+	
+	// Format results
+	var resultText strings.Builder
+	if query != "" {
+		resultText.WriteString(fmt.Sprintf("# Search Results for \"%s\"\n\n", query))
+	} else {
+		resultText.WriteString("# All Recipes\n\n")
+	}
+	
+	if len(matchedRecipes) == 0 {
+		if query != "" {
+			resultText.WriteString("No recipes found matching your search.\n")
+		} else {
+			resultText.WriteString("No recipes found in your collection.\n")
+		}
+	} else {
+		resultText.WriteString(fmt.Sprintf("Found %d recipe(s):\n\n", len(matchedRecipes)))
+		
+		for i, recipe := range matchedRecipes {
+			resultText.WriteString(fmt.Sprintf("%d. **%s**\n", i+1, recipe.Name))
+			if recipe.Description != "" {
+				resultText.WriteString(fmt.Sprintf("   _%s_\n", recipe.Description))
+			}
+			resultText.WriteString(fmt.Sprintf("   UID: %s\n", recipe.UID))
+			if recipe.Servings != "" {
+				resultText.WriteString(fmt.Sprintf("   Servings: %s\n", recipe.Servings))
+			}
+			if recipe.PrepTime != "" || recipe.CookTime != "" {
+				timeInfo := ""
+				if recipe.PrepTime != "" {
+					timeInfo += fmt.Sprintf("Prep: %s", recipe.PrepTime)
+				}
+				if recipe.CookTime != "" {
+					if timeInfo != "" {
+						timeInfo += ", "
+					}
+					timeInfo += fmt.Sprintf("Cook: %s", recipe.CookTime)
+				}
+				resultText.WriteString(fmt.Sprintf("   Time: %s\n", timeInfo))
+			}
+			resultText.WriteString("\n")
+		}
+	}
+	
+	return mcp.NewToolResultText(resultText.String()), nil
+}
+
+func (s *Server) addMealToPlan(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	start := time.Now()
+	
+	// Get parameters
+	date, ok := req.Params.Arguments["date"].(string)
+	if !ok || date == "" {
+		return nil, errors.New("date is required")
+	}
+	mealName, ok := req.Params.Arguments["meal_name"].(string)
+	if !ok || mealName == "" {
+		return nil, errors.New("meal_name is required")
+	}
+	
+	mealType := 2 // Default to dinner
+	if val, ok := req.Params.Arguments["meal_type"].(float64); ok {
+		mealType = int(val)
+	}
+	
+	recipeUID := ""
+	if val, ok := req.Params.Arguments["recipe_uid"].(string); ok {
+		recipeUID = strings.TrimSpace(val)
+	}
+	
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	
+	// Create meal plan entry with ALL required fields
+	// Format date correctly: "YYYY-MM-DD 00:00:00"
+	formattedDate := date + " 00:00:00"
+	
+	meal := paprika.MealPlan{
+		Date:      formattedDate,
+		Name:      mealName,
+		Type:      mealType,
+		RecipeUID: recipeUID,
+		OrderFlag: 0,
+	}
+	
+	// Save the meal plan entry
+	savedMeal, err := s.paprika3.SaveMealPlan(ctx, meal)
+	if err != nil {
+		return nil, fmt.Errorf("failed to add meal to plan: %w", err)
+	}
+	
+	duration := time.Since(start)
+	s.logger.Info("Added meal to plan", "date", date, "meal", mealName, "type", mealType, "duration", duration)
+	
+	// Format result
+	var resultText strings.Builder
+	resultText.WriteString("# Meal Added Successfully\n\n")
+	
+	mealTypeStr := "Dinner"
+	switch mealType {
+	case 0:
+		mealTypeStr = "Breakfast"
+	case 1:
+		mealTypeStr = "Lunch"
+	case 2:
+		mealTypeStr = "Dinner"
+	}
+	
+	resultText.WriteString(fmt.Sprintf("Added **%s** as %s on %s\n\n", mealName, mealTypeStr, date))
+	resultText.WriteString(fmt.Sprintf("- **Date**: %s\n", date))
+	resultText.WriteString(fmt.Sprintf("- **Meal**: %s\n", mealName))
+	resultText.WriteString(fmt.Sprintf("- **Type**: %s\n", mealTypeStr))
+	if recipeUID != "" {
+		resultText.WriteString(fmt.Sprintf("- **Recipe ID**: %s\n", recipeUID))
+	}
+	resultText.WriteString(fmt.Sprintf("- **Meal ID**: %s\n\n", savedMeal.UID))
+	
+	resultText.WriteString("The meal has been added to your Paprika meal plan calendar.\n")
+	
+	return mcp.NewToolResultText(resultText.String()), nil
+}
+
+func (s *Server) removeMealFromPlan(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	start := time.Now()
+	
+	// Get meal UID parameter
+	mealUID, ok := req.Params.Arguments["meal_uid"].(string)
+	if !ok || mealUID == "" {
+		return nil, errors.New("meal_uid is required")
+	}
+	
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	
+	// Delete the meal plan entry
+	err := s.paprika3.DeleteMealPlan(ctx, mealUID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to remove meal from plan: %w", err)
+	}
+	
+	duration := time.Since(start)
+	s.logger.Info("Removed meal from plan", "meal_uid", mealUID, "duration", duration)
+	
+	// Format result
+	var resultText strings.Builder
+	resultText.WriteString("# Meal Removed Successfully\n\n")
+	resultText.WriteString(fmt.Sprintf("Removed meal with ID **%s** from your meal plan.\n\n", mealUID))
+	resultText.WriteString("The meal has been deleted from your Paprika meal plan calendar.\n")
+	
+	return mcp.NewToolResultText(resultText.String()), nil
+}
+
+func (s *Server) inspectMealData(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	start := time.Now()
+	
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	
+	// Get meal plan data
+	mealPlanResp, err := s.paprika3.ListMealPlan(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get meal plan: %w", err)
+	}
+	
+	duration := time.Since(start)
+	s.logger.Info("Retrieved meal plan for inspection", "count", len(mealPlanResp.Result), "duration", duration)
+	
+	// Format results with detailed inspection
+	var resultText strings.Builder
+	resultText.WriteString("# Meal Plan Data Inspection\n\n")
+	
+	if len(mealPlanResp.Result) == 0 {
+		resultText.WriteString("No meals found in your meal plan.\n")
+	} else {
+		resultText.WriteString(fmt.Sprintf("Found %d meal entries. Showing detailed structure:\n\n", len(mealPlanResp.Result)))
+		
+		// Show first few meals with full JSON structure
+		limit := 5
+		if len(mealPlanResp.Result) < limit {
+			limit = len(mealPlanResp.Result)
+		}
+		
+		for i, meal := range mealPlanResp.Result[:limit] {
+			resultText.WriteString(fmt.Sprintf("## Meal %d: %s\n", i+1, meal.Name))
+			resultText.WriteString(fmt.Sprintf("- **Date**: %s\n", meal.Date))
+			resultText.WriteString(fmt.Sprintf("- **UID**: %s\n", meal.UID))
+			resultText.WriteString(fmt.Sprintf("- **Recipe UID**: %s\n", meal.RecipeUID))
+			resultText.WriteString(fmt.Sprintf("- **Type**: %d\n", meal.Type))
+			resultText.WriteString(fmt.Sprintf("- **Order Flag**: %d\n", meal.OrderFlag))
+			resultText.WriteString(fmt.Sprintf("- **Deleted**: %t\n", meal.Deleted))
+			
+			// JSON representation
+			mealJSON, err := json.MarshalIndent(meal, "", "  ")
+			if err == nil {
+				resultText.WriteString("\n**Raw JSON Structure:**\n```json\n")
+				resultText.WriteString(string(mealJSON))
+				resultText.WriteString("\n```\n\n")
+			}
+		}
+		
+		if len(mealPlanResp.Result) > limit {
+			resultText.WriteString(fmt.Sprintf("... and %d more meals\n", len(mealPlanResp.Result)-limit))
+		}
+	}
+	
+	return mcp.NewToolResultText(resultText.String()), nil
+}
+
+func (s *Server) listMealPlan(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	start := time.Now()
+	
+	// Get date filters if provided
+	startDate := ""
+	if val, ok := req.Params.Arguments["start_date"].(string); ok {
+		startDate = strings.TrimSpace(val)
+	}
+	endDate := ""
+	if val, ok := req.Params.Arguments["end_date"].(string); ok {
+		endDate = strings.TrimSpace(val)
+	}
+	
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	
+	// Get meal plan from Paprika
+	mealPlanResp, err := s.paprika3.ListMealPlan(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get meal plan: %w", err)
+	}
+	
+	// Filter by date range if specified
+	var filteredMeals []paprika.MealPlan
+	for _, meal := range mealPlanResp.Result {
+		if startDate != "" && meal.Date < startDate {
+			continue
+		}
+		if endDate != "" && meal.Date > endDate {
+			continue
+		}
+		filteredMeals = append(filteredMeals, meal)
+	}
+	
+	duration := time.Since(start)
+	s.logger.Info("Retrieved meal plan", "total", len(mealPlanResp.Result), "filtered", len(filteredMeals), "duration", duration)
+	
+	// Format results
+	var resultText strings.Builder
+	resultText.WriteString("# Meal Plan\n\n")
+	
+	if startDate != "" || endDate != "" {
+		resultText.WriteString(fmt.Sprintf("Showing meals from %s to %s\n\n", startDate, endDate))
+	}
+	
+	if len(filteredMeals) == 0 {
+		resultText.WriteString("No meals found in the specified date range.\n")
+	} else {
+		resultText.WriteString(fmt.Sprintf("Found %d scheduled meal(s):\n\n", len(filteredMeals)))
+		
+		// Group by date
+		mealsByDate := make(map[string][]paprika.MealPlan)
+		for _, meal := range filteredMeals {
+			mealsByDate[meal.Date] = append(mealsByDate[meal.Date], meal)
+		}
+		
+		// Sort dates
+		dates := make([]string, 0, len(mealsByDate))
+		for date := range mealsByDate {
+			dates = append(dates, date)
+		}
+		// Simple sort for dates in YYYY-MM-DD format
+		for i := 0; i < len(dates); i++ {
+			for j := i + 1; j < len(dates); j++ {
+				if dates[i] > dates[j] {
+					dates[i], dates[j] = dates[j], dates[i]
+				}
+			}
+		}
+		
+		for _, date := range dates {
+			meals := mealsByDate[date]
+			resultText.WriteString(fmt.Sprintf("## %s\n", date))
+			
+			for _, meal := range meals {
+				mealType := "Meal"
+				switch meal.Type {
+				case 1:
+					mealType = "Lunch"
+				case 2:
+					mealType = "Dinner"
+				case 0:
+					mealType = "Breakfast"
+				}
+				
+				resultText.WriteString(fmt.Sprintf("- **%s**: %s", mealType, meal.Name))
+				if meal.RecipeUID != "" {
+					resultText.WriteString(fmt.Sprintf(" (Recipe ID: %s)", meal.RecipeUID))
+				}
+				resultText.WriteString("\n")
+			}
+			resultText.WriteString("\n")
+		}
+	}
+	
+	return mcp.NewToolResultText(resultText.String()), nil
+}
+
+func (s *Server) listGroceries(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	start := time.Now()
+	
+	// Get filter parameter
+	filter := "all"
+	if val, ok := req.Params.Arguments["filter"].(string); ok {
+		filter = strings.ToLower(strings.TrimSpace(val))
+	}
+	
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	
+	// Get groceries from Paprika
+	groceryResp, err := s.paprika3.ListGroceries(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get groceries: %w", err)
+	}
+	
+	// Filter items based on purchase status
+	var filteredItems []paprika.GroceryItem
+	for _, item := range groceryResp.Result {
+		switch filter {
+		case "purchased":
+			if item.Purchased {
+				filteredItems = append(filteredItems, item)
+			}
+		case "unpurchased":
+			if !item.Purchased {
+				filteredItems = append(filteredItems, item)
+			}
+		default: // "all"
+			filteredItems = append(filteredItems, item)
+		}
+	}
+	
+	duration := time.Since(start)
+	s.logger.Info("Retrieved groceries", "total", len(groceryResp.Result), "filtered", len(filteredItems), "filter", filter, "duration", duration)
+	
+	// Format results
+	var resultText strings.Builder
+	resultText.WriteString("# Grocery List\n\n")
+	
+	if len(filteredItems) == 0 {
+		resultText.WriteString("No grocery items found.\n")
+	} else {
+		resultText.WriteString(fmt.Sprintf("Found %d grocery item(s):\n\n", len(filteredItems)))
+		
+		// Group by aisle
+		itemsByAisle := make(map[string][]paprika.GroceryItem)
+		for _, item := range filteredItems {
+			aisle := item.Aisle
+			if aisle == "" {
+				aisle = "Other"
+			}
+			itemsByAisle[aisle] = append(itemsByAisle[aisle], item)
+		}
+		
+		// Sort aisles alphabetically
+		aisles := make([]string, 0, len(itemsByAisle))
+		for aisle := range itemsByAisle {
+			aisles = append(aisles, aisle)
+		}
+		for i := 0; i < len(aisles); i++ {
+			for j := i + 1; j < len(aisles); j++ {
+				if aisles[i] > aisles[j] {
+					aisles[i], aisles[j] = aisles[j], aisles[i]
+				}
+			}
+		}
+		
+		for _, aisle := range aisles {
+			items := itemsByAisle[aisle]
+			resultText.WriteString(fmt.Sprintf("## %s\n", aisle))
+			
+			for _, item := range items {
+				status := "☐"
+				if item.Purchased {
+					status = "☑"
+				}
+				
+				resultText.WriteString(fmt.Sprintf("%s **%s**", status, item.Ingredient))
+				if item.Quantity != "" {
+					resultText.WriteString(fmt.Sprintf(" (%s)", item.Quantity))
+				}
+				if item.Recipe != "" {
+					resultText.WriteString(fmt.Sprintf(" - for %s", item.Recipe))
+				}
+				if item.Instruction != "" {
+					resultText.WriteString(fmt.Sprintf(" _%s_", item.Instruction))
+				}
+				resultText.WriteString("\n")
+			}
+			resultText.WriteString("\n")
+		}
+	}
+	
+	return mcp.NewToolResultText(resultText.String()), nil
+}
+
+func (s *Server) exploreAPI(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	start := time.Now()
+	
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	
+	// First try to get meal plan data
+	mealPlanResp, err := s.paprika3.ListMealPlan(ctx)
+	if err != nil {
+		s.logger.Error("failed to get meal plan data", "error", err)
+	}
+	
+	// Try to get grocery data
+	groceryResp, err := s.paprika3.ListGroceries(ctx)
+	if err != nil {
+		s.logger.Error("failed to get grocery data", "error", err)
+	}
+	
+	// Explore other API endpoints
+	err = s.paprika3.ExploreAPI(ctx)
+	if err != nil {
+		s.logger.Error("failed to explore API", "error", err)
+	}
+	
+	duration := time.Since(start)
+	s.logger.Info("API exploration completed", "duration", duration)
+	
+	var resultText strings.Builder
+	resultText.WriteString("# Paprika API Exploration Results\n\n")
+	resultText.WriteString("Explored various API endpoints to find meal planning and grocery features.\n\n")
+	
+	if mealPlanResp != nil {
+		resultText.WriteString(fmt.Sprintf("## Meal Plan API\nFound %d meal entries\n\n", len(mealPlanResp.Result)))
+	}
+	
+	if groceryResp != nil {
+		resultText.WriteString(fmt.Sprintf("## Grocery API\nFound %d grocery items\n\n", len(groceryResp.Result)))
+	}
+	
+	resultText.WriteString("Check the server logs for detailed exploration results of all attempted endpoints.\n")
+	
+	return mcp.NewToolResultText(resultText.String()), nil
 }

--- a/internal/paprika/client.go
+++ b/internal/paprika/client.go
@@ -220,6 +220,7 @@ type GroceryItem struct {
 	Quantity    string `json:"quantity"`
 	AisleUID    string `json:"aisle_uid"`
 	ListUID     string `json:"list_uid"`
+	Deleted     bool   `json:"deleted"` // Soft delete flag (like MealPlan)
 }
 
 type GroceryResponse struct {
@@ -637,80 +638,6 @@ func (c *Client) ListGroceries(ctx context.Context) (*GroceryResponse, error) {
 	return &groceryResp, nil
 }
 
-// ExploreAPI tries common endpoint patterns to discover available APIs
-func (c *Client) ExploreAPI(ctx context.Context) error {
-	endpoints := []string{
-		"https://paprikaapp.com/api/v2/sync/",
-		"https://paprikaapp.com/api/v2/sync/meals",
-		"https://paprikaapp.com/api/v2/sync/menu",
-		"https://paprikaapp.com/api/v2/sync/menus",
-		"https://paprikaapp.com/api/v2/sync/mealplan", 
-		"https://paprikaapp.com/api/v2/sync/groceries",
-		"https://paprikaapp.com/api/v2/sync/grocery",
-		"https://paprikaapp.com/api/v2/sync/pantry",
-		"https://paprikaapp.com/api/v2/sync/categories",
-	}
-
-	// Also try POST requests to see if we can create meal entries
-	mealEndpoints := []string{
-		"https://paprikaapp.com/api/v2/sync/meals",
-		"https://paprikaapp.com/api/v2/sync/meal",
-	}
-
-	// Try GET requests first
-	for _, endpoint := range endpoints {
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
-		if err != nil {
-			continue
-		}
-
-		resp, err := c.client.Do(req)
-		if err != nil {
-			continue
-		}
-
-		rawBytes, err := io.ReadAll(resp.Body)
-		resp.Body.Close()
-		if err != nil {
-			continue
-		}
-
-		previewLen := 200
-		if len(rawBytes) < previewLen {
-			previewLen = len(rawBytes)
-		}
-		c.logger.Info("API exploration (GET)", "endpoint", endpoint, "status", resp.StatusCode, "response_length", len(rawBytes), "response", string(rawBytes)[:previewLen])
-	}
-
-	// Try POST requests to meal endpoints
-	for _, endpoint := range mealEndpoints {
-		// Try with empty body first
-		req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader("{}"))
-		if err != nil {
-			continue
-		}
-		req.Header.Set("Content-Type", "application/json")
-
-		resp, err := c.client.Do(req)
-		if err != nil {
-			continue
-		}
-
-		rawBytes, err := io.ReadAll(resp.Body)
-		resp.Body.Close()
-		if err != nil {
-			continue
-		}
-
-		previewLen := 200
-		if len(rawBytes) < previewLen {
-			previewLen = len(rawBytes)
-		}
-		c.logger.Info("API exploration (POST)", "endpoint", endpoint, "status", resp.StatusCode, "response_length", len(rawBytes), "response", string(rawBytes)[:previewLen])
-	}
-
-	return nil
-}
 
 // SaveMealPlan saves a meal plan entry to Paprika API using V1 API with meals array
 func (c *Client) SaveMealPlan(ctx context.Context, meal MealPlan) (*MealPlan, error) {
@@ -766,15 +693,15 @@ func (c *Client) SaveMealPlan(ctx context.Context, meal MealPlan) (*MealPlan, er
 	// Use V1 API endpoint: /api/v1/sync/meals/ (plural, no UID)
 	endpoint := "https://paprikaapp.com/api/v1/sync/meals/"
 	c.logger.Info("Using V1 API endpoint", "url", endpoint)
-	
+
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, &body)
 	if err != nil {
 		c.logger.Error("failed to create request", "error", err)
 		return nil, err
 	}
-	
+
 	// V1 API requires Basic Auth instead of Bearer token
-	credentials := base64.StdEncoding.EncodeToString([]byte(c.username +":" + c.password))
+	credentials := base64.StdEncoding.EncodeToString([]byte(c.username + ":" + c.password))
 	req.Header.Set("Authorization", "Basic "+credentials)
 	req.Header.Set("Content-Type", multipartWriter.FormDataContentType())
 	req.ContentLength = int64(body.Len())
@@ -810,17 +737,75 @@ func (c *Client) SaveMealPlan(ctx context.Context, meal MealPlan) (*MealPlan, er
 	return &meal, nil
 }
 
-// DeleteMealPlan deletes a meal plan entry from Paprika API
+// DeleteMealPlan deletes a meal plan entry from Paprika API using soft delete
+// Based on Kappari documentation: deletion is via deleted flag, not HTTP DELETE
 func (c *Client) DeleteMealPlan(ctx context.Context, uid string) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, fmt.Sprintf("https://paprikaapp.com/api/v2/sync/meal/%s/", uid), nil)
+	c.logger.Info("Soft-deleting meal plan using Kappari approach", "uid", uid)
+
+	// Create a meal plan with deleted flag set to true
+	meal := MealPlan{
+		UID:     uid,
+		Deleted: true, // Soft delete flag
+	}
+
+	// Use the same SaveMealPlan approach but with deleted=true
+	mealsArray := []MealPlan{meal}
+	mealArrayData, err := json.Marshal(mealsArray)
+	if err != nil {
+		c.logger.Error("failed to marshal delete meal plan", "error", err)
+		return err
+	}
+
+	// Create gzipped data
+	var buf bytes.Buffer
+	writer := gzip.NewWriter(&buf)
+	_, err = writer.Write(mealArrayData)
+	if err != nil {
+		writer.Close()
+		return err
+	}
+	if err := writer.Close(); err != nil {
+		return err
+	}
+	gzippedData := buf.Bytes()
+
+	// Create multipart form request
+	var body bytes.Buffer
+	multipartWriter := multipart.NewWriter(&body)
+	part, err := multipartWriter.CreateFormFile("data", "data")
+	if err != nil {
+		c.logger.Error("failed to create form file for delete", "error", err)
+		return err
+	}
+
+	if _, err := part.Write(gzippedData); err != nil {
+		c.logger.Error("failed to write gzipped delete data", "error", err)
+		return err
+	}
+	if err := multipartWriter.Close(); err != nil {
+		c.logger.Error("failed to close multipart writer for delete", "error", err)
+		return err
+	}
+
+	// Use V1 API endpoint with Basic Auth (like SaveMealPlan)
+	endpoint := "https://paprikaapp.com/api/v1/sync/meals/"
+	c.logger.Info("Using V1 API endpoint for soft delete", "url", endpoint)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, &body)
 	if err != nil {
 		c.logger.Error("failed to create delete request", "error", err)
 		return err
 	}
 
+	// V1 API requires Basic Auth
+	credentials := base64.StdEncoding.EncodeToString([]byte(c.username + ":" + c.password))
+	req.Header.Set("Authorization", "Basic "+credentials)
+	req.Header.Set("Content-Type", multipartWriter.FormDataContentType())
+	req.ContentLength = int64(body.Len())
+
 	resp, err := c.client.Do(req)
 	if err != nil {
-		c.logger.Error("failed to delete meal", "error", err)
+		c.logger.Error("failed to soft delete meal plan", "error", err)
 		return err
 	}
 	defer resp.Body.Close()
@@ -831,11 +816,216 @@ func (c *Client) DeleteMealPlan(ctx context.Context, uid string) error {
 		return err
 	}
 
-	c.logger.Info("DeleteMeal response", "status", resp.StatusCode, "response", string(rawBytes))
+	c.logger.Info("DeleteMealPlan (soft delete) response", "status", resp.StatusCode, "response", string(rawBytes))
 
 	if resp.StatusCode != http.StatusOK {
-		c.logger.Error("failed to delete meal", "status", resp.Status, "response", string(rawBytes))
-		return fmt.Errorf("failed to delete meal: %s - %s", resp.Status, string(rawBytes))
+		c.logger.Error("failed to soft delete meal plan", "status", resp.Status, "response", string(rawBytes))
+		return fmt.Errorf("failed to soft delete meal plan: %s - %s", resp.Status, string(rawBytes))
+	}
+
+	if err := isErrorResponse(rawBytes); err != nil {
+		c.logger.Error("meal plan soft delete returned error", "error", err)
+		return err
+	}
+
+	// Trigger sync notification
+	defer c.notify(ctx)
+
+	return nil
+}
+
+// SaveGroceryItem saves a grocery item to Paprika API using V1 API with groceries array
+func (c *Client) SaveGroceryItem(ctx context.Context, item GroceryItem) (*GroceryItem, error) {
+	// Generate UUID if not provided
+	if item.UID == "" {
+		item.UID = strings.ToUpper(uuid.New().String())
+	}
+
+	// Set default values for required fields
+	if item.OrderFlag == 0 {
+		item.OrderFlag = 0
+	}
+	if item.Name == "" {
+		item.Name = item.Ingredient // Use ingredient as name if not provided
+	}
+
+	c.logger.Info("Saving grocery item using V1 API", "uid", item.UID, "ingredient", item.Ingredient, "aisle", item.Aisle)
+
+	// Wrap single item in array as required by V1 API
+	itemsArray := []GroceryItem{item}
+	itemArrayData, err := json.Marshal(itemsArray)
+	if err != nil {
+		c.logger.Error("failed to marshal grocery items array", "error", err)
+		return nil, err
+	}
+
+	// Create gzipped data
+	var buf bytes.Buffer
+	writer := gzip.NewWriter(&buf)
+	_, err = writer.Write(itemArrayData)
+	if err != nil {
+		writer.Close()
+		return nil, err
+	}
+	if err := writer.Close(); err != nil {
+		return nil, err
+	}
+	gzippedData := buf.Bytes()
+
+	// Create multipart form request
+	var body bytes.Buffer
+	multipartWriter := multipart.NewWriter(&body)
+	part, err := multipartWriter.CreateFormFile("data", "data")
+	if err != nil {
+		c.logger.Error("failed to create form file", "error", err)
+		return nil, err
+	}
+
+	if _, err := part.Write(gzippedData); err != nil {
+		c.logger.Error("failed to write gzipped grocery data", "error", err)
+		return nil, err
+	}
+	if err := multipartWriter.Close(); err != nil {
+		c.logger.Error("failed to close multipart writer", "error", err)
+		return nil, err
+	}
+
+	// Use V1 API endpoint: /api/v1/sync/groceries/ (plural, no UID)
+	endpoint := "https://paprikaapp.com/api/v1/sync/groceries/"
+	c.logger.Info("Using V1 API endpoint", "url", endpoint)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, &body)
+	if err != nil {
+		c.logger.Error("failed to create request", "error", err)
+		return nil, err
+	}
+
+	// V1 API requires Basic Auth instead of Bearer token
+	credentials := base64.StdEncoding.EncodeToString([]byte(c.username + ":" + c.password))
+	req.Header.Set("Authorization", "Basic "+credentials)
+	req.Header.Set("Content-Type", multipartWriter.FormDataContentType())
+	req.ContentLength = int64(body.Len())
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		c.logger.Error("failed to save grocery item", "error", err)
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	rawBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		c.logger.Error("failed to read response body", "error", err)
+		return nil, err
+	}
+
+	c.logger.Info("SaveGroceryItem V1 API response", "status", resp.StatusCode, "response", string(rawBytes))
+
+	if resp.StatusCode != http.StatusOK {
+		c.logger.Error("failed to save grocery item", "status", resp.Status, "response", string(rawBytes))
+		return nil, fmt.Errorf("failed to save grocery item: %s - %s", resp.Status, string(rawBytes))
+	}
+
+	if err := isErrorResponse(rawBytes); err != nil {
+		c.logger.Error("grocery item save returned error", "error", err)
+		return nil, err
+	}
+
+	// Trigger sync notification
+	defer c.notify(ctx)
+
+	return &item, nil
+}
+
+// DeleteGroceryItem deletes a grocery item from Paprika API using soft delete
+// Based on Kappari documentation: deletion is "likely via deleted flag" not HTTP DELETE
+func (c *Client) DeleteGroceryItem(ctx context.Context, uid string) error {
+	c.logger.Info("Soft-deleting grocery item using Kappari approach", "uid", uid)
+
+	// Create a grocery item with deleted flag set to true
+	item := GroceryItem{
+		UID:     uid,
+		Deleted: true, // Soft delete flag
+	}
+
+	// Use the same SaveGroceryItem approach but with deleted=true
+	itemsArray := []GroceryItem{item}
+	itemArrayData, err := json.Marshal(itemsArray)
+	if err != nil {
+		c.logger.Error("failed to marshal delete grocery item", "error", err)
+		return err
+	}
+
+	// Create gzipped data
+	var buf bytes.Buffer
+	writer := gzip.NewWriter(&buf)
+	_, err = writer.Write(itemArrayData)
+	if err != nil {
+		writer.Close()
+		return err
+	}
+	if err := writer.Close(); err != nil {
+		return err
+	}
+	gzippedData := buf.Bytes()
+
+	// Create multipart form request
+	var body bytes.Buffer
+	multipartWriter := multipart.NewWriter(&body)
+	part, err := multipartWriter.CreateFormFile("data", "data")
+	if err != nil {
+		c.logger.Error("failed to create form file for delete", "error", err)
+		return err
+	}
+
+	if _, err := part.Write(gzippedData); err != nil {
+		c.logger.Error("failed to write gzipped delete data", "error", err)
+		return err
+	}
+	if err := multipartWriter.Close(); err != nil {
+		c.logger.Error("failed to close multipart writer for delete", "error", err)
+		return err
+	}
+
+	// Try V1 API endpoint with Basic Auth (like SaveGroceryItem)
+	endpoint := "https://paprikaapp.com/api/v1/sync/groceries/"
+	c.logger.Info("Using V1 API endpoint for soft delete", "url", endpoint)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, &body)
+	if err != nil {
+		c.logger.Error("failed to create delete request", "error", err)
+		return err
+	}
+
+	// V1 API requires Basic Auth
+	credentials := base64.StdEncoding.EncodeToString([]byte(c.username + ":" + c.password))
+	req.Header.Set("Authorization", "Basic "+credentials)
+	req.Header.Set("Content-Type", multipartWriter.FormDataContentType())
+	req.ContentLength = int64(body.Len())
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		c.logger.Error("failed to soft delete grocery item", "error", err)
+		return err
+	}
+	defer resp.Body.Close()
+
+	rawBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		c.logger.Error("failed to read delete response body", "error", err)
+		return err
+	}
+
+	c.logger.Info("DeleteGroceryItem (soft delete) response", "status", resp.StatusCode, "response", string(rawBytes))
+
+	if resp.StatusCode != http.StatusOK {
+		c.logger.Error("failed to soft delete grocery item", "status", resp.Status, "response", string(rawBytes))
+		return fmt.Errorf("failed to soft delete grocery item: %s - %s", resp.Status, string(rawBytes))
+	}
+
+	if err := isErrorResponse(rawBytes); err != nil {
+		c.logger.Error("grocery item soft delete returned error", "error", err)
+		return err
 	}
 
 	// Trigger sync notification

--- a/internal/paprika/client.go
+++ b/internal/paprika/client.go
@@ -5,6 +5,7 @@ import (
 	"compress/gzip"
 	"context"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -83,14 +84,18 @@ func NewClient(username, password, version string, logger *slog.Logger) (*Client
 	}
 
 	return &Client{
-		client: client,
-		logger: l,
+		client:   client,
+		logger:   l,
+		username: username,
+		password: password,
 	}, nil
 }
 
 type Client struct {
-	client *http.Client
-	logger *slog.Logger
+	client   *http.Client
+	logger   *slog.Logger
+	username string
+	password string
 }
 
 type loginResponse struct {
@@ -186,6 +191,39 @@ func (c *Client) ListRecipes(ctx context.Context) (*RecipeList, error) {
 
 	c.logger.Info("found recipes", "count", len(recipeList.Result))
 	return &recipeList, nil
+}
+
+type MealPlan struct {
+	UID       string `json:"uid"`
+	RecipeUID string `json:"recipe_uid"`
+	Date      string `json:"date"`
+	Type      int    `json:"type"`
+	Name      string `json:"name"`
+	OrderFlag int    `json:"order_flag"`
+	Deleted   bool   `json:"deleted"`
+}
+
+type MealPlanResponse struct {
+	Result []MealPlan `json:"result"`
+}
+
+type GroceryItem struct {
+	UID         string `json:"uid"`
+	RecipeUID   string `json:"recipe_uid"`
+	Name        string `json:"name"`
+	OrderFlag   int    `json:"order_flag"`
+	Purchased   bool   `json:"purchased"`
+	Aisle       string `json:"aisle"`
+	Ingredient  string `json:"ingredient"`
+	Recipe      string `json:"recipe"`
+	Instruction string `json:"instruction"`
+	Quantity    string `json:"quantity"`
+	AisleUID    string `json:"aisle_uid"`
+	ListUID     string `json:"list_uid"`
+}
+
+type GroceryResponse struct {
+	Result []GroceryItem `json:"result"`
 }
 
 type Recipe struct {
@@ -523,6 +561,285 @@ func isErrorResponse(body []byte) error {
 	if errResp.Error.Message != "" || errResp.Error.Code != 0 {
 		return fmt.Errorf("error: %s (code: %d)", errResp.Error.Message, errResp.Error.Code)
 	}
+
+	return nil
+}
+
+// ListMealPlan retrieves meal plan data from Paprika API
+func (c *Client) ListMealPlan(ctx context.Context) (*MealPlanResponse, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://paprikaapp.com/api/v2/sync/meals", nil)
+	if err != nil {
+		c.logger.Error("failed to create request", "error", err)
+		return nil, err
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		c.logger.Error("failed to get meals", "error", err)
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		c.logger.Error("failed to get meals", "status", resp.Status)
+		return nil, fmt.Errorf("failed to get meals: %s", resp.Status)
+	}
+
+	rawBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		c.logger.Error("failed to read response body", "error", err)
+		return nil, err
+	}
+
+	var mealPlanResp MealPlanResponse
+	if err := json.Unmarshal(rawBytes, &mealPlanResp); err != nil {
+		c.logger.Error("failed to unmarshal meal plan response", "error", err)
+		return nil, err
+	}
+
+	c.logger.Info("Retrieved meal plan", "count", len(mealPlanResp.Result))
+	return &mealPlanResp, nil
+}
+
+// ListGroceries retrieves grocery list data from Paprika API
+func (c *Client) ListGroceries(ctx context.Context) (*GroceryResponse, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://paprikaapp.com/api/v2/sync/groceries", nil)
+	if err != nil {
+		c.logger.Error("failed to create request", "error", err)
+		return nil, err
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		c.logger.Error("failed to get groceries", "error", err)
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		c.logger.Error("failed to get groceries", "status", resp.Status)
+		return nil, fmt.Errorf("failed to get groceries: %s", resp.Status)
+	}
+
+	rawBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		c.logger.Error("failed to read response body", "error", err)
+		return nil, err
+	}
+
+	var groceryResp GroceryResponse
+	if err := json.Unmarshal(rawBytes, &groceryResp); err != nil {
+		c.logger.Error("failed to unmarshal grocery response", "error", err)
+		return nil, err
+	}
+
+	c.logger.Info("Retrieved groceries", "count", len(groceryResp.Result))
+	return &groceryResp, nil
+}
+
+// ExploreAPI tries common endpoint patterns to discover available APIs
+func (c *Client) ExploreAPI(ctx context.Context) error {
+	endpoints := []string{
+		"https://paprikaapp.com/api/v2/sync/",
+		"https://paprikaapp.com/api/v2/sync/meals",
+		"https://paprikaapp.com/api/v2/sync/menu",
+		"https://paprikaapp.com/api/v2/sync/menus",
+		"https://paprikaapp.com/api/v2/sync/mealplan", 
+		"https://paprikaapp.com/api/v2/sync/groceries",
+		"https://paprikaapp.com/api/v2/sync/grocery",
+		"https://paprikaapp.com/api/v2/sync/pantry",
+		"https://paprikaapp.com/api/v2/sync/categories",
+	}
+
+	// Also try POST requests to see if we can create meal entries
+	mealEndpoints := []string{
+		"https://paprikaapp.com/api/v2/sync/meals",
+		"https://paprikaapp.com/api/v2/sync/meal",
+	}
+
+	// Try GET requests first
+	for _, endpoint := range endpoints {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+		if err != nil {
+			continue
+		}
+
+		resp, err := c.client.Do(req)
+		if err != nil {
+			continue
+		}
+
+		rawBytes, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			continue
+		}
+
+		previewLen := 200
+		if len(rawBytes) < previewLen {
+			previewLen = len(rawBytes)
+		}
+		c.logger.Info("API exploration (GET)", "endpoint", endpoint, "status", resp.StatusCode, "response_length", len(rawBytes), "response", string(rawBytes)[:previewLen])
+	}
+
+	// Try POST requests to meal endpoints
+	for _, endpoint := range mealEndpoints {
+		// Try with empty body first
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader("{}"))
+		if err != nil {
+			continue
+		}
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := c.client.Do(req)
+		if err != nil {
+			continue
+		}
+
+		rawBytes, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			continue
+		}
+
+		previewLen := 200
+		if len(rawBytes) < previewLen {
+			previewLen = len(rawBytes)
+		}
+		c.logger.Info("API exploration (POST)", "endpoint", endpoint, "status", resp.StatusCode, "response_length", len(rawBytes), "response", string(rawBytes)[:previewLen])
+	}
+
+	return nil
+}
+
+// SaveMealPlan saves a meal plan entry to Paprika API using V1 API with meals array
+func (c *Client) SaveMealPlan(ctx context.Context, meal MealPlan) (*MealPlan, error) {
+	// Generate UUID if not provided
+	if meal.UID == "" {
+		meal.UID = strings.ToUpper(uuid.New().String())
+	}
+
+	// Set required "deleted" field to false
+	meal.Deleted = false
+
+	c.logger.Info("Saving meal using V1 API", "uid", meal.UID, "name", meal.Name, "date", meal.Date, "type", meal.Type)
+
+	// Wrap single meal in array as required by V1 API
+	mealsArray := []MealPlan{meal}
+	mealArrayData, err := json.Marshal(mealsArray)
+	if err != nil {
+		c.logger.Error("failed to marshal meals array", "error", err)
+		return nil, err
+	}
+
+	// Create gzipped data
+	var buf bytes.Buffer
+	writer := gzip.NewWriter(&buf)
+	_, err = writer.Write(mealArrayData)
+	if err != nil {
+		writer.Close()
+		return nil, err
+	}
+	if err := writer.Close(); err != nil {
+		return nil, err
+	}
+	gzippedData := buf.Bytes()
+
+	// Create multipart form request
+	var body bytes.Buffer
+	multipartWriter := multipart.NewWriter(&body)
+	part, err := multipartWriter.CreateFormFile("data", "data")
+	if err != nil {
+		c.logger.Error("failed to create form file", "error", err)
+		return nil, err
+	}
+
+	if _, err := part.Write(gzippedData); err != nil {
+		c.logger.Error("failed to write gzipped meal data", "error", err)
+		return nil, err
+	}
+	if err := multipartWriter.Close(); err != nil {
+		c.logger.Error("failed to close multipart writer", "error", err)
+		return nil, err
+	}
+
+	// Use V1 API endpoint: /api/v1/sync/meals/ (plural, no UID)
+	endpoint := "https://paprikaapp.com/api/v1/sync/meals/"
+	c.logger.Info("Using V1 API endpoint", "url", endpoint)
+	
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, &body)
+	if err != nil {
+		c.logger.Error("failed to create request", "error", err)
+		return nil, err
+	}
+	
+	// V1 API requires Basic Auth instead of Bearer token
+	credentials := base64.StdEncoding.EncodeToString([]byte(c.username +":" + c.password))
+	req.Header.Set("Authorization", "Basic "+credentials)
+	req.Header.Set("Content-Type", multipartWriter.FormDataContentType())
+	req.ContentLength = int64(body.Len())
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		c.logger.Error("failed to save meal", "error", err)
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	rawBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		c.logger.Error("failed to read response body", "error", err)
+		return nil, err
+	}
+
+	c.logger.Info("SaveMeal V1 API response", "status", resp.StatusCode, "response", string(rawBytes))
+
+	if resp.StatusCode != http.StatusOK {
+		c.logger.Error("failed to save meal", "status", resp.Status, "response", string(rawBytes))
+		return nil, fmt.Errorf("failed to save meal: %s - %s", resp.Status, string(rawBytes))
+	}
+
+	if err := isErrorResponse(rawBytes); err != nil {
+		c.logger.Error("meal save returned error", "error", err)
+		return nil, err
+	}
+
+	// Trigger sync notification
+	defer c.notify(ctx)
+
+	return &meal, nil
+}
+
+// DeleteMealPlan deletes a meal plan entry from Paprika API
+func (c *Client) DeleteMealPlan(ctx context.Context, uid string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, fmt.Sprintf("https://paprikaapp.com/api/v2/sync/meal/%s/", uid), nil)
+	if err != nil {
+		c.logger.Error("failed to create delete request", "error", err)
+		return err
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		c.logger.Error("failed to delete meal", "error", err)
+		return err
+	}
+	defer resp.Body.Close()
+
+	rawBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		c.logger.Error("failed to read delete response body", "error", err)
+		return err
+	}
+
+	c.logger.Info("DeleteMeal response", "status", resp.StatusCode, "response", string(rawBytes))
+
+	if resp.StatusCode != http.StatusOK {
+		c.logger.Error("failed to delete meal", "status", resp.Status, "response", string(rawBytes))
+		return fmt.Errorf("failed to delete meal: %s - %s", resp.Status, string(rawBytes))
+	}
+
+	// Trigger sync notification
+	defer c.notify(ctx)
 
 	return nil
 }


### PR DESCRIPTION
## Add Meal Planning & Grocery Management Support

resolves #2 

### Summary
Adds meal planning and grocery list management capabilities to complement the existing recipe tools.

### New Tools

**Recipe Management**
- `get_recipe` - Retrieve full recipe details by UID
- `search_recipes` - Search and list recipes

**Meal Planning**
- `list_meal_plan` - View scheduled meals with optional date filtering
- `add_meal_to_plan` - Add meals to calendar
- `remove_meal_from_plan` - Remove meals from plan

**Grocery Management**
- `list_groceries` - View shopping list items
- `add_grocery_item` - Add items to shopping list
- `remove_grocery_item` - Remove items from shopping list

### Implementation Notes

- Uses Paprika V1 API (Basic Auth) for meal and grocery operations
- Uses V2 API (Bearer token) for recipe operations
- Implements soft delete pattern for meals and groceries (`deleted: true` flag)
- Sends data as gzipped JSON arrays in multipart forms per API requirements

### Changes
- Added meal plan and grocery list client methods
- Added corresponding MCP tool handlers
- Updated README with new tools
- Updated `.gitignore` to exclude build artifacts and personal config files