### PR TITLE
Fix meal and grocery sync: use V2 bulk endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *.so
 *.dylib
 bin
+paprika-3-mcp
 
 # Test binary, built with `go test -c`
 *.test

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # paprika-3-mcp
 
-A [Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction) server that exposes your **Paprika 3** recipes as LLM-readable resources — and lets an LLM like Claude create or update recipes in your Paprika app.
+A [Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction) server that connects your **Paprika 3** account to LLMs like Claude — manage recipes, plan meals, and build grocery lists through natural conversation.
 
 ### 🖼️ Example: Claude using the Paprika MCP server
 
@@ -19,10 +19,24 @@ See anything missing? Open an issue on this repo to request a feature!
 
 #### 🛠 **Tools**
 
-- `create_paprika_recipe`  
-  Allows Claude to save a new recipe to your Paprika app
-- `update_paprika_recipe`  
-  Allows Claude to modify an existing recipe
+**Recipe Management**
+- `create_paprika_recipe` — Create new recipes in your Paprika app
+- `update_paprika_recipe` — Modify existing recipes by UID
+- `get_recipe` — Get full recipe details (ingredients, directions, etc.) by UID
+- `list_recipes` — List all recipes with names, UIDs, and basic info (fast, parallel fetch)
+- `search_recipes` — Deep search recipes by keyword across name, ingredients, and description
+- `delete_recipe` — Move a recipe to the trash by UID (soft delete; recoverable in the Paprika app)
+
+**Meal Planning**
+- `list_meal_plan` — View scheduled meals, optionally filtered by date range
+- `add_meal_to_plan` — Schedule a meal (Breakfast, Lunch, or Dinner) with an optional recipe link
+- `remove_meal_from_plan` — Remove a meal from the plan by UID
+
+**Grocery Management**
+- `list_grocery_lists` — View all grocery lists (Paprika supports multiple lists, e.g. one per store)
+- `list_groceries` — View grocery items across all lists, grouped by aisle, with purchase status
+- `add_grocery_item` — Add an item to a grocery list (defaults to the default list; specify `list_uid` for others)
+- `remove_grocery_item` — Remove an item by name (case-insensitive partial match)
 
 ## ⚙️ Prerequisites
 

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -617,6 +617,27 @@ func (s *Server) addGroceryItem(ctx context.Context, req mcp.CallToolRequest) (*
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
+	// Paprika orphans grocery items posted with an empty list_uid: the POST
+	// returns 200 but the item is attached to no list and never surfaces in the
+	// app (meals are unaffected because they key off date, not a list). When the
+	// caller doesn't specify a list, resolve the account's default grocery list
+	// and attach the item to it — the behavior this tool already advertises.
+	if listUID == "" {
+		lists, err := s.paprika3.ListGroceryLists(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve default grocery list: %w", err)
+		}
+		for _, l := range lists.Result {
+			if l.IsDefault {
+				listUID = l.UID
+				break
+			}
+		}
+		if listUID == "" {
+			return nil, errors.New("no default grocery list found; pass an explicit list_uid")
+		}
+	}
+
 	// Create grocery item
 	item := paprika.GroceryItem{
 		Ingredient:  ingredient,

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -5,6 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sort"
+	"strings"
+	"sync"
 	"time"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -12,11 +15,26 @@ import (
 	"github.com/soggycactus/paprika-3-mcp/internal/paprika"
 )
 
+// PaprikaClient defines the interface for interacting with the Paprika API.
+// This is implemented by *paprika.Client and can be mocked for testing.
+type PaprikaClient interface {
+	ListRecipes(ctx context.Context) (*paprika.RecipeList, error)
+	GetRecipe(ctx context.Context, uid string) (*paprika.Recipe, error)
+	SaveRecipe(ctx context.Context, recipe paprika.Recipe) (*paprika.Recipe, error)
+	DeleteRecipe(ctx context.Context, recipe paprika.Recipe) (*paprika.Recipe, error)
+	ListMealPlan(ctx context.Context) (*paprika.MealPlanResponse, error)
+	SaveMealPlan(ctx context.Context, meal paprika.MealPlan) (*paprika.MealPlan, error)
+	DeleteMealPlan(ctx context.Context, uid string) error
+	ListGroceries(ctx context.Context) (*paprika.GroceryResponse, error)
+	ListGroceryLists(ctx context.Context) (*paprika.GroceryListResponse, error)
+	SaveGroceryItem(ctx context.Context, item paprika.GroceryItem) (*paprika.GroceryItem, error)
+	DeleteGroceryItem(ctx context.Context, uid string) error
+}
+
 type NewServerOptions struct {
 	Version  string
 	Username string
 	Password string
-	Paprika  *paprika.Client
 	Logger   *slog.Logger
 }
 
@@ -35,7 +53,7 @@ func NewServer(opts NewServerOptions) (*Server, error) {
 }
 
 type Server struct {
-	paprika3 *paprika.Client
+	paprika3 PaprikaClient
 	logger   *slog.Logger
 	server   *server.MCPServer
 }
@@ -68,12 +86,98 @@ func (s *Server) Start() {
 		mcp.WithString("cook_time", mcp.Description("The cook time for the recipe"), mcp.Required()),
 		mcp.WithString("difficulty", mcp.Description("The difficulty of the recipe"), mcp.Required()),
 	)
+	listRecipesTool := mcp.NewTool("list_recipes",
+		mcp.WithDescription("List all recipes in the Paprika collection, sorted alphabetically. Returns recipe name, UID, description, servings, and timing info. Use get_recipe with a UID to retrieve full details including ingredients and directions. To find recipes by ingredient or description text, use search_recipes instead."),
+		mcp.WithNumber("limit", mcp.Description("Maximum number of recipes to return. 0 means no limit."), mcp.DefaultNumber(0)),
+	)
+	searchRecipesTool := mcp.NewTool("search_recipes",
+		mcp.WithDescription("Search recipes by keyword across name, ingredients, and description text. Use this when you need to find recipes containing a specific ingredient or term. For browsing or listing all recipes, use list_recipes instead."),
+		mcp.WithString("query", mcp.Description("Search term to match against recipe name, ingredients, and description. Case-insensitive. Multiple words are AND-matched (e.g. 'chicken pasta' finds recipes containing both words)."), mcp.Required()),
+		mcp.WithNumber("limit", mcp.Description("Maximum number of matching recipes to return (default 10)."), mcp.DefaultNumber(10)),
+	)
+	listMealPlanTool := mcp.NewTool("list_meal_plan",
+		mcp.WithDescription("List scheduled meals from the Paprika meal plan, grouped by date. Each meal has a UID, name, type (Breakfast/Lunch/Dinner), and optionally a linked recipe UID. Use the meal UID with remove_meal_from_plan to delete entries."),
+		mcp.WithString("start_date", mcp.Description("Filter to meals on or after this date. Format: YYYY-MM-DD. If omitted, no lower bound is applied."), mcp.DefaultString("")),
+		mcp.WithString("end_date", mcp.Description("Filter to meals on or before this date. Format: YYYY-MM-DD. If omitted, no upper bound is applied."), mcp.DefaultString("")),
+	)
+	listGroceriesTool := mcp.NewTool("list_groceries",
+		mcp.WithDescription("List grocery items across all grocery lists in Paprika. Items are grouped by aisle. Each item includes its list_uid indicating which grocery list it belongs to."),
+		mcp.WithString("filter", mcp.Description("Filter by purchase status: 'purchased', 'unpurchased', or 'all'"), mcp.DefaultString("all")),
+	)
+	addMealTool := mcp.NewTool("add_meal_to_plan",
+		mcp.WithDescription("Add a meal to the Paprika meal plan calendar. A meal can optionally be linked to an existing recipe by providing its UID (use search_recipes to find recipe UIDs). Defaults to Dinner if no meal_type is specified."),
+		mcp.WithString("date", mcp.Description("Date to schedule the meal. Format: YYYY-MM-DD."), mcp.Required()),
+		mcp.WithString("meal_name", mcp.Description("Display name of the meal (e.g. 'Spaghetti Bolognese')"), mcp.Required()),
+		mcp.WithNumber("meal_type", mcp.Description("Meal type: 0 = Breakfast, 1 = Lunch, 2 = Dinner. Defaults to 2 (Dinner)."), mcp.DefaultNumber(2)),
+		mcp.WithString("recipe_uid", mcp.Description("UID of a Paprika recipe to link to this meal. Optional. Use search_recipes to find recipe UIDs."), mcp.DefaultString("")),
+	)
+	removeMealTool := mcp.NewTool("remove_meal_from_plan",
+		mcp.WithDescription("Remove a meal from the Paprika meal plan. This is a soft delete. Use list_meal_plan to find the meal UID to remove."),
+		mcp.WithString("meal_uid", mcp.Description("UID of the meal to remove. Get this from the list_meal_plan results."), mcp.Required()),
+	)
+	getRecipeTool := mcp.NewTool("get_recipe",
+		mcp.WithDescription("Get full recipe details by UID. Returns the complete recipe including name, ingredients, directions, prep/cook time, servings, notes, and description as formatted Markdown. Use search_recipes first to find recipe UIDs."),
+		mcp.WithString("uid", mcp.Description("UID of the recipe. Get this from search_recipes results or from a meal plan entry's recipe_uid."), mcp.Required()),
+	)
+	listGroceryListsTool := mcp.NewTool("list_grocery_lists",
+		mcp.WithDescription("List all grocery/shopping lists in the Paprika account. Paprika supports multiple grocery lists (e.g. one per store). Each list has a UID and a name. One list is marked as the default. Use the list UIDs with add_grocery_item to add items to a specific list."),
+	)
+	addGroceryItemTool := mcp.NewTool("add_grocery_item",
+		mcp.WithDescription("Add an item to a Paprika grocery/shopping list. If no list_uid is provided, the item is added to the user's default grocery list. To add to a specific list, first call list_grocery_lists to get the available list UIDs."),
+		mcp.WithString("ingredient", mcp.Description("The ingredient/item name"), mcp.Required()),
+		mcp.WithString("list_uid", mcp.Description("UID of the grocery list to add the item to. If omitted, the item is added to the default list. Call list_grocery_lists to discover available lists and their UIDs."), mcp.DefaultString("")),
+		mcp.WithString("aisle", mcp.Description("Store aisle where item is located (optional)"), mcp.DefaultString("")),
+		mcp.WithString("quantity", mcp.Description("Quantity needed (optional)"), mcp.DefaultString("")),
+		mcp.WithString("recipe", mcp.Description("Recipe this ingredient is for (optional)"), mcp.DefaultString("")),
+		mcp.WithString("instruction", mcp.Description("Special instructions (optional)"), mcp.DefaultString("")),
+	)
+	removeGroceryItemTool := mcp.NewTool("remove_grocery_item",
+		mcp.WithDescription("Remove an item from a Paprika grocery list by name. Performs a case-insensitive search across ingredient and item names. If multiple items match, only the first match is removed and the others are reported. This is a soft delete."),
+		mcp.WithString("item_name", mcp.Description("Name or partial name of the item to remove. Searches ingredient and item names case-insensitively. Use list_groceries to see current items."), mcp.Required()),
+	)
+	deleteRecipeTool := mcp.NewTool("delete_recipe",
+		mcp.WithDescription("Delete a recipe from Paprika by moving it to the trash (soft delete). The recipe can be recovered from the trash in the Paprika app. Use list_recipes or search_recipes to find the recipe UID."),
+		mcp.WithString("uid", mcp.Description("UID of the recipe to delete. Get this from list_recipes or search_recipes results."), mcp.Required()),
+	)
 	s.server.AddTools(server.ServerTool{
 		Tool:    createRecipeTool,
 		Handler: s.createRecipe,
 	}, server.ServerTool{
 		Tool:    updateRecipeTool,
 		Handler: s.updateRecipe,
+	}, server.ServerTool{
+		Tool:    listRecipesTool,
+		Handler: s.listRecipes,
+	}, server.ServerTool{
+		Tool:    searchRecipesTool,
+		Handler: s.searchRecipes,
+	}, server.ServerTool{
+		Tool:    listMealPlanTool,
+		Handler: s.listMealPlan,
+	}, server.ServerTool{
+		Tool:    listGroceriesTool,
+		Handler: s.listGroceries,
+	}, server.ServerTool{
+		Tool:    addMealTool,
+		Handler: s.addMealToPlan,
+	}, server.ServerTool{
+		Tool:    removeMealTool,
+		Handler: s.removeMealFromPlan,
+	}, server.ServerTool{
+		Tool:    getRecipeTool,
+		Handler: s.getRecipe,
+	}, server.ServerTool{
+		Tool:    listGroceryListsTool,
+		Handler: s.listGroceryLists,
+	}, server.ServerTool{
+		Tool:    addGroceryItemTool,
+		Handler: s.addGroceryItem,
+	}, server.ServerTool{
+		Tool:    removeGroceryItemTool,
+		Handler: s.removeGroceryItem,
+	}, server.ServerTool{
+		Tool:    deleteRecipeTool,
+		Handler: s.deleteRecipe,
 	})
 
 	if err := server.ServeStdio(s.server); err != nil {
@@ -178,12 +282,31 @@ func (s *Server) createRecipe(ctx context.Context, req mcp.CallToolRequest) (*mc
 	if !ok || len(directions) == 0 {
 		return nil, errors.New("directions are required")
 	}
-	servings := req.Params.Arguments["servings"].(string)
-	prepTime := req.Params.Arguments["prep_time"].(string)
-	cookTime := req.Params.Arguments["cook_time"].(string)
-	description := req.Params.Arguments["description"].(string)
-	notes := req.Params.Arguments["notes"].(string)
-	difficulty := req.Params.Arguments["difficulty"].(string)
+	// Handle optional string fields safely
+	servings := ""
+	if val, ok := req.Params.Arguments["servings"].(string); ok {
+		servings = val
+	}
+	prepTime := ""
+	if val, ok := req.Params.Arguments["prep_time"].(string); ok {
+		prepTime = val
+	}
+	cookTime := ""
+	if val, ok := req.Params.Arguments["cook_time"].(string); ok {
+		cookTime = val
+	}
+	description := ""
+	if val, ok := req.Params.Arguments["description"].(string); ok {
+		description = val
+	}
+	notes := ""
+	if val, ok := req.Params.Arguments["notes"].(string); ok {
+		notes = val
+	}
+	difficulty := ""
+	if val, ok := req.Params.Arguments["difficulty"].(string); ok {
+		difficulty = val
+	}
 
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
@@ -230,29 +353,30 @@ func (s *Server) updateRecipe(ctx context.Context, req mcp.CallToolRequest) (*mc
 	if !ok || len(directions) == 0 {
 		return nil, errors.New("directions are required")
 	}
-	description, ok := req.Params.Arguments["description"].(string)
-	if !ok {
-		return nil, errors.New("description is required")
+	// Handle optional string fields safely
+	description := ""
+	if val, ok := req.Params.Arguments["description"].(string); ok {
+		description = val
 	}
-	servings, ok := req.Params.Arguments["servings"].(string)
-	if !ok {
-		return nil, errors.New("servings is required")
+	servings := ""
+	if val, ok := req.Params.Arguments["servings"].(string); ok {
+		servings = val
 	}
-	prepTime, ok := req.Params.Arguments["prep_time"].(string)
-	if !ok {
-		return nil, errors.New("prepTime is required")
+	prepTime := ""
+	if val, ok := req.Params.Arguments["prep_time"].(string); ok {
+		prepTime = val
 	}
-	cookTime, ok := req.Params.Arguments["cook_time"].(string)
-	if !ok {
-		return nil, errors.New("cookTime is required")
+	cookTime := ""
+	if val, ok := req.Params.Arguments["cook_time"].(string); ok {
+		cookTime = val
 	}
-	notes, ok := req.Params.Arguments["notes"].(string)
-	if !ok {
-		return nil, errors.New("notes is required")
+	notes := ""
+	if val, ok := req.Params.Arguments["notes"].(string); ok {
+		notes = val
 	}
-	difficulty, ok := req.Params.Arguments["difficulty"].(string)
-	if !ok {
-		return nil, errors.New("difficulty is required")
+	difficulty := ""
+	if val, ok := req.Params.Arguments["difficulty"].(string); ok {
+		difficulty = val
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
@@ -281,4 +405,702 @@ func (s *Server) updateRecipe(ctx context.Context, req mcp.CallToolRequest) (*mc
 		MIMEType: "text/markdown",
 		Text:     recipe.ToMarkdown(),
 	}), nil
+}
+
+// fetchAllRecipes fetches full details for all recipes concurrently, filtering out trashed recipes.
+func (s *Server) fetchAllRecipes(ctx context.Context) ([]paprika.Recipe, error) {
+	recipeList, err := s.paprika3.ListRecipes(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list recipes: %w", err)
+	}
+
+	type result struct {
+		recipe paprika.Recipe
+		err    error
+	}
+
+	results := make([]result, len(recipeList.Result))
+	var wg sync.WaitGroup
+	sem := make(chan struct{}, 10) // limit concurrency
+
+	for i, info := range recipeList.Result {
+		wg.Add(1)
+		go func(i int, uid string) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			recipe, err := s.paprika3.GetRecipe(ctx, uid)
+			if err != nil {
+				results[i] = result{err: err}
+				return
+			}
+			results[i] = result{recipe: *recipe}
+		}(i, info.UID)
+	}
+	wg.Wait()
+
+	var recipes []paprika.Recipe
+	for _, r := range results {
+		if r.err != nil {
+			s.logger.Error("failed to get recipe details", "error", r.err)
+			continue
+		}
+		if r.recipe.InTrash {
+			continue
+		}
+		recipes = append(recipes, r.recipe)
+	}
+	return recipes, nil
+}
+
+func formatRecipeList(recipes []paprika.Recipe) string {
+	var resultText strings.Builder
+	for i, recipe := range recipes {
+		resultText.WriteString(fmt.Sprintf("%d. **%s**\n", i+1, recipe.Name))
+		if recipe.Description != "" {
+			resultText.WriteString(fmt.Sprintf("   _%s_\n", recipe.Description))
+		}
+		resultText.WriteString(fmt.Sprintf("   UID: %s\n", recipe.UID))
+		if recipe.Servings != "" {
+			resultText.WriteString(fmt.Sprintf("   Servings: %s\n", recipe.Servings))
+		}
+		if recipe.PrepTime != "" || recipe.CookTime != "" {
+			timeInfo := ""
+			if recipe.PrepTime != "" {
+				timeInfo += fmt.Sprintf("Prep: %s", recipe.PrepTime)
+			}
+			if recipe.CookTime != "" {
+				if timeInfo != "" {
+					timeInfo += ", "
+				}
+				timeInfo += fmt.Sprintf("Cook: %s", recipe.CookTime)
+			}
+			resultText.WriteString(fmt.Sprintf("   Time: %s\n", timeInfo))
+		}
+		resultText.WriteString("\n")
+	}
+	return resultText.String()
+}
+
+func (s *Server) listRecipes(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	start := time.Now()
+
+	limit := 0
+	if val, ok := req.Params.Arguments["limit"].(float64); ok {
+		limit = int(val)
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	defer cancel()
+
+	recipes, err := s.fetchAllRecipes(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Sort by name for consistent output
+	sort.Slice(recipes, func(i, j int) bool {
+		return strings.ToLower(recipes[i].Name) < strings.ToLower(recipes[j].Name)
+	})
+
+	if limit > 0 && len(recipes) > limit {
+		recipes = recipes[:limit]
+	}
+
+	duration := time.Since(start)
+	s.logger.Info("Listed recipes", "count", len(recipes), "duration", duration)
+
+	var resultText strings.Builder
+	resultText.WriteString("# All Recipes\n\n")
+	if len(recipes) == 0 {
+		resultText.WriteString("No recipes found in your collection.\n")
+	} else {
+		resultText.WriteString(fmt.Sprintf("Found %d recipe(s):\n\n", len(recipes)))
+		resultText.WriteString(formatRecipeList(recipes))
+	}
+
+	return mcp.NewToolResultText(resultText.String()), nil
+}
+
+func (s *Server) searchRecipes(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	start := time.Now()
+
+	query := ""
+	if val, ok := req.Params.Arguments["query"].(string); ok {
+		query = strings.ToLower(strings.TrimSpace(val))
+	}
+	if query == "" {
+		return nil, errors.New("query is required — use list_recipes to browse all recipes")
+	}
+
+	limit := 10
+	if val, ok := req.Params.Arguments["limit"].(float64); ok {
+		limit = int(val)
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	defer cancel()
+
+	recipes, err := s.fetchAllRecipes(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Split query into words — all words must match somewhere in name/ingredients/description
+	queryWords := strings.Fields(query)
+
+	var matched []paprika.Recipe
+	for _, recipe := range recipes {
+		searchText := strings.ToLower(recipe.Name + " " + recipe.Ingredients + " " + recipe.Description)
+		allMatch := true
+		for _, word := range queryWords {
+			if !strings.Contains(searchText, word) {
+				allMatch = false
+				break
+			}
+		}
+		if allMatch {
+			matched = append(matched, recipe)
+			if len(matched) >= limit {
+				break
+			}
+		}
+	}
+
+	duration := time.Since(start)
+	s.logger.Info("Search completed", "query", query, "matches", len(matched), "duration", duration)
+
+	var resultText strings.Builder
+	resultText.WriteString(fmt.Sprintf("# Search Results for \"%s\"\n\n", query))
+	if len(matched) == 0 {
+		resultText.WriteString("No recipes found matching your search.\n")
+	} else {
+		resultText.WriteString(fmt.Sprintf("Found %d recipe(s):\n\n", len(matched)))
+		resultText.WriteString(formatRecipeList(matched))
+	}
+
+	return mcp.NewToolResultText(resultText.String()), nil
+}
+
+func (s *Server) addGroceryItem(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	start := time.Now()
+
+	// Get required parameter
+	ingredient, ok := req.Params.Arguments["ingredient"].(string)
+	if !ok || ingredient == "" {
+		return nil, errors.New("ingredient is required")
+	}
+
+	// Get optional parameters
+	listUID := ""
+	if val, ok := req.Params.Arguments["list_uid"].(string); ok {
+		listUID = strings.TrimSpace(val)
+	}
+	aisle := ""
+	if val, ok := req.Params.Arguments["aisle"].(string); ok {
+		aisle = strings.TrimSpace(val)
+	}
+	quantity := ""
+	if val, ok := req.Params.Arguments["quantity"].(string); ok {
+		quantity = strings.TrimSpace(val)
+	}
+	recipe := ""
+	if val, ok := req.Params.Arguments["recipe"].(string); ok {
+		recipe = strings.TrimSpace(val)
+	}
+	instruction := ""
+	if val, ok := req.Params.Arguments["instruction"].(string); ok {
+		instruction = strings.TrimSpace(val)
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	// Create grocery item
+	item := paprika.GroceryItem{
+		Ingredient:  ingredient,
+		Name:        ingredient, // Use ingredient name as display name
+		ListUID:     listUID,
+		Aisle:       aisle,
+		Quantity:    quantity,
+		Recipe:      recipe,
+		Instruction: instruction,
+		Purchased:   false, // New items are not purchased
+		OrderFlag:   0,
+	}
+
+	// Save the grocery item
+	savedItem, err := s.paprika3.SaveGroceryItem(ctx, item)
+	if err != nil {
+		return nil, fmt.Errorf("failed to add grocery item: %w", err)
+	}
+
+	duration := time.Since(start)
+	s.logger.Info("Added grocery item", "ingredient", ingredient, "aisle", aisle, "duration", duration)
+
+	// Format result
+	var resultText strings.Builder
+	resultText.WriteString("# Grocery Item Added Successfully\n\n")
+	resultText.WriteString(fmt.Sprintf("Added **%s** to your grocery list\n\n", ingredient))
+	resultText.WriteString(fmt.Sprintf("- **Item**: %s\n", ingredient))
+	if quantity != "" {
+		resultText.WriteString(fmt.Sprintf("- **Quantity**: %s\n", quantity))
+	}
+	if aisle != "" {
+		resultText.WriteString(fmt.Sprintf("- **Aisle**: %s\n", aisle))
+	}
+	if recipe != "" {
+		resultText.WriteString(fmt.Sprintf("- **For Recipe**: %s\n", recipe))
+	}
+	if instruction != "" {
+		resultText.WriteString(fmt.Sprintf("- **Instructions**: %s\n", instruction))
+	}
+	resultText.WriteString(fmt.Sprintf("- **Item ID**: %s\n\n", savedItem.UID))
+	resultText.WriteString("The item has been added to your Paprika grocery list.\n")
+
+	return mcp.NewToolResultText(resultText.String()), nil
+}
+
+func (s *Server) removeGroceryItem(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	start := time.Now()
+
+	// Get item name parameter
+	itemName, ok := req.Params.Arguments["item_name"].(string)
+	if !ok || itemName == "" {
+		return nil, errors.New("item_name is required")
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	// Get current grocery list to find the item
+	groceryResp, err := s.paprika3.ListGroceries(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get grocery list: %w", err)
+	}
+
+	// Find matching items (case-insensitive search)
+	searchTerm := strings.ToLower(strings.TrimSpace(itemName))
+	var matchedItems []paprika.GroceryItem
+	for _, item := range groceryResp.Result {
+		if strings.Contains(strings.ToLower(item.Ingredient), searchTerm) ||
+			strings.Contains(strings.ToLower(item.Name), searchTerm) {
+			matchedItems = append(matchedItems, item)
+		}
+	}
+
+	if len(matchedItems) == 0 {
+		return mcp.NewToolResultText(fmt.Sprintf("# No Items Found\n\nNo grocery items found matching \"%s\". Use list_groceries to see your current list.", itemName)), nil
+	}
+
+	// If multiple matches, remove the first one but inform the user
+	itemToRemove := matchedItems[0]
+	err = s.paprika3.DeleteGroceryItem(ctx, itemToRemove.UID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to remove grocery item: %w", err)
+	}
+
+	duration := time.Since(start)
+	s.logger.Info("Removed grocery item", "ingredient", itemToRemove.Ingredient, "uid", itemToRemove.UID, "duration", duration)
+
+	// Format result
+	var resultText strings.Builder
+	resultText.WriteString("# Grocery Item Removed Successfully\n\n")
+	resultText.WriteString(fmt.Sprintf("Removed **%s** from your grocery list.\n\n", itemToRemove.Ingredient))
+
+	if len(matchedItems) > 1 {
+		resultText.WriteString(fmt.Sprintf("Note: Found %d items matching \"%s\". Removed the first match:\n", len(matchedItems), itemName))
+		for i, item := range matchedItems {
+			status := "❌ REMOVED"
+			if i > 0 {
+				status = "⚠️  Still in list"
+			}
+			resultText.WriteString(fmt.Sprintf("- %s %s", status, item.Ingredient))
+			if item.Quantity != "" {
+				resultText.WriteString(fmt.Sprintf(" (%s)", item.Quantity))
+			}
+			resultText.WriteString("\n")
+		}
+		resultText.WriteString("\nTo remove additional items, run the command again.\n")
+	} else {
+		resultText.WriteString("The item has been removed from your Paprika grocery list.\n")
+	}
+
+	return mcp.NewToolResultText(resultText.String()), nil
+}
+
+func (s *Server) getRecipe(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	start := time.Now()
+
+	uid, ok := req.Params.Arguments["uid"].(string)
+	if !ok || uid == "" {
+		return nil, errors.New("uid is required")
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	recipe, err := s.paprika3.GetRecipe(ctx, uid)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get recipe: %w", err)
+	}
+
+	duration := time.Since(start)
+	s.logger.Info("Retrieved recipe", "name", recipe.Name, "uid", recipe.UID, "duration", duration)
+
+	return mcp.NewToolResultText(recipe.ToMarkdown()), nil
+}
+
+func (s *Server) deleteRecipe(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	start := time.Now()
+
+	uid, ok := req.Params.Arguments["uid"].(string)
+	if !ok || uid == "" {
+		return nil, errors.New("uid is required")
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	// Fetch the recipe first so we can pass it to DeleteRecipe
+	recipe, err := s.paprika3.GetRecipe(ctx, uid)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get recipe: %w", err)
+	}
+
+	_, err = s.paprika3.DeleteRecipe(ctx, *recipe)
+	if err != nil {
+		return nil, fmt.Errorf("failed to delete recipe: %w", err)
+	}
+
+	duration := time.Since(start)
+	s.logger.Info("Deleted recipe", "name", recipe.Name, "uid", recipe.UID, "duration", duration)
+
+	var resultText strings.Builder
+	resultText.WriteString("# Recipe Deleted Successfully\n\n")
+	resultText.WriteString(fmt.Sprintf("Moved **%s** to the trash.\n\n", recipe.Name))
+	resultText.WriteString("The recipe can be recovered from the trash in the Paprika app.\n")
+
+	return mcp.NewToolResultText(resultText.String()), nil
+}
+
+func (s *Server) addMealToPlan(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	start := time.Now()
+
+	// Get parameters
+	date, ok := req.Params.Arguments["date"].(string)
+	if !ok || date == "" {
+		return nil, errors.New("date is required")
+	}
+	mealName, ok := req.Params.Arguments["meal_name"].(string)
+	if !ok || mealName == "" {
+		return nil, errors.New("meal_name is required")
+	}
+
+	mealType := paprika.MealTypeDinner
+	if val, ok := req.Params.Arguments["meal_type"].(float64); ok {
+		mealType = int(val)
+	}
+
+	recipeUID := ""
+	if val, ok := req.Params.Arguments["recipe_uid"].(string); ok {
+		recipeUID = strings.TrimSpace(val)
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	// Create meal plan entry with ALL required fields
+	// Format date correctly: "YYYY-MM-DD 00:00:00"
+	formattedDate := date + " 00:00:00"
+
+	meal := paprika.MealPlan{
+		Date:      formattedDate,
+		Name:      mealName,
+		Type:      mealType,
+		RecipeUID: recipeUID,
+		OrderFlag: 0,
+	}
+
+	// Save the meal plan entry
+	savedMeal, err := s.paprika3.SaveMealPlan(ctx, meal)
+	if err != nil {
+		return nil, fmt.Errorf("failed to add meal to plan: %w", err)
+	}
+
+	duration := time.Since(start)
+	s.logger.Info("Added meal to plan", "date", date, "meal", mealName, "type", mealType, "duration", duration)
+
+	// Format result
+	var resultText strings.Builder
+	resultText.WriteString("# Meal Added Successfully\n\n")
+
+	mealTypeStr := paprika.MealTypeName(mealType)
+
+	resultText.WriteString(fmt.Sprintf("Added **%s** as %s on %s\n\n", mealName, mealTypeStr, date))
+	resultText.WriteString(fmt.Sprintf("- **Date**: %s\n", date))
+	resultText.WriteString(fmt.Sprintf("- **Meal**: %s\n", mealName))
+	resultText.WriteString(fmt.Sprintf("- **Type**: %s\n", mealTypeStr))
+	if recipeUID != "" {
+		resultText.WriteString(fmt.Sprintf("- **Recipe ID**: %s\n", recipeUID))
+	}
+	resultText.WriteString(fmt.Sprintf("- **Meal ID**: %s\n\n", savedMeal.UID))
+
+	resultText.WriteString("The meal has been added to your Paprika meal plan calendar.\n")
+
+	return mcp.NewToolResultText(resultText.String()), nil
+}
+
+func (s *Server) removeMealFromPlan(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	start := time.Now()
+
+	// Get meal UID parameter
+	mealUID, ok := req.Params.Arguments["meal_uid"].(string)
+	if !ok || mealUID == "" {
+		return nil, errors.New("meal_uid is required")
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	// Delete the meal plan entry
+	err := s.paprika3.DeleteMealPlan(ctx, mealUID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to remove meal from plan: %w", err)
+	}
+
+	duration := time.Since(start)
+	s.logger.Info("Removed meal from plan", "meal_uid", mealUID, "duration", duration)
+
+	// Format result
+	var resultText strings.Builder
+	resultText.WriteString("# Meal Removed Successfully\n\n")
+	resultText.WriteString(fmt.Sprintf("Removed meal with ID **%s** from your meal plan.\n\n", mealUID))
+	resultText.WriteString("The meal has been deleted from your Paprika meal plan calendar.\n")
+
+	return mcp.NewToolResultText(resultText.String()), nil
+}
+
+func (s *Server) listMealPlan(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	start := time.Now()
+
+	// Get date filters if provided
+	startDate := ""
+	if val, ok := req.Params.Arguments["start_date"].(string); ok {
+		startDate = strings.TrimSpace(val)
+	}
+	endDate := ""
+	if val, ok := req.Params.Arguments["end_date"].(string); ok {
+		endDate = strings.TrimSpace(val)
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	// Get meal plan from Paprika
+	mealPlanResp, err := s.paprika3.ListMealPlan(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get meal plan: %w", err)
+	}
+
+	// Filter by date range if specified, and exclude deleted meals
+	var filteredMeals []paprika.MealPlan
+	for _, meal := range mealPlanResp.Result {
+		if meal.Deleted {
+			continue
+		}
+		// Normalize meal date to YYYY-MM-DD for comparison (API returns "YYYY-MM-DD HH:MM:SS")
+		mealDate := meal.Date
+		if len(mealDate) > 10 {
+			mealDate = mealDate[:10]
+		}
+		if startDate != "" && mealDate < startDate {
+			continue
+		}
+		if endDate != "" && mealDate > endDate {
+			continue
+		}
+		filteredMeals = append(filteredMeals, meal)
+	}
+
+	duration := time.Since(start)
+	s.logger.Info("Retrieved meal plan", "total", len(mealPlanResp.Result), "filtered", len(filteredMeals), "duration", duration)
+
+	// Format results
+	var resultText strings.Builder
+	resultText.WriteString("# Meal Plan\n\n")
+
+	if startDate != "" || endDate != "" {
+		resultText.WriteString(fmt.Sprintf("Showing meals from %s to %s\n\n", startDate, endDate))
+	}
+
+	if len(filteredMeals) == 0 {
+		resultText.WriteString("No meals found in the specified date range.\n")
+	} else {
+		resultText.WriteString(fmt.Sprintf("Found %d scheduled meal(s):\n\n", len(filteredMeals)))
+
+		// Group by date
+		mealsByDate := make(map[string][]paprika.MealPlan)
+		for _, meal := range filteredMeals {
+			mealsByDate[meal.Date] = append(mealsByDate[meal.Date], meal)
+		}
+
+		// Sort dates
+		dates := make([]string, 0, len(mealsByDate))
+		for date := range mealsByDate {
+			dates = append(dates, date)
+		}
+		sort.Strings(dates)
+
+		for _, date := range dates {
+			meals := mealsByDate[date]
+			resultText.WriteString(fmt.Sprintf("## %s\n", date))
+
+			for _, meal := range meals {
+				mealType := paprika.MealTypeName(meal.Type)
+
+				resultText.WriteString(fmt.Sprintf("- **%s**: %s", mealType, meal.Name))
+				if meal.RecipeUID != "" {
+					resultText.WriteString(fmt.Sprintf(" (Recipe ID: %s)", meal.RecipeUID))
+				}
+				resultText.WriteString("\n")
+			}
+			resultText.WriteString("\n")
+		}
+	}
+
+	return mcp.NewToolResultText(resultText.String()), nil
+}
+
+func (s *Server) listGroceryLists(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	start := time.Now()
+
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	resp, err := s.paprika3.ListGroceryLists(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get grocery lists: %w", err)
+	}
+
+	duration := time.Since(start)
+	s.logger.Info("Retrieved grocery lists", "count", len(resp.Result), "duration", duration)
+
+	var resultText strings.Builder
+	resultText.WriteString("# Grocery Lists\n\n")
+
+	if len(resp.Result) == 0 {
+		resultText.WriteString("No grocery lists found.\n")
+	} else {
+		resultText.WriteString(fmt.Sprintf("Found %d grocery list(s):\n\n", len(resp.Result)))
+		for _, list := range resp.Result {
+			if list.Deleted {
+				continue
+			}
+			defaultMarker := ""
+			if list.IsDefault {
+				defaultMarker = " (default)"
+			}
+			resultText.WriteString(fmt.Sprintf("- **%s**%s\n  UID: %s\n", list.Name, defaultMarker, list.UID))
+		}
+	}
+
+	return mcp.NewToolResultText(resultText.String()), nil
+}
+
+func (s *Server) listGroceries(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	start := time.Now()
+
+	// Get filter parameter
+	filter := "all"
+	if val, ok := req.Params.Arguments["filter"].(string); ok {
+		filter = strings.ToLower(strings.TrimSpace(val))
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	// Get groceries from Paprika
+	groceryResp, err := s.paprika3.ListGroceries(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get groceries: %w", err)
+	}
+
+	// Filter items based on purchase status, excluding deleted items
+	var filteredItems []paprika.GroceryItem
+	for _, item := range groceryResp.Result {
+		if item.Deleted {
+			continue
+		}
+		switch filter {
+		case "purchased":
+			if item.Purchased {
+				filteredItems = append(filteredItems, item)
+			}
+		case "unpurchased":
+			if !item.Purchased {
+				filteredItems = append(filteredItems, item)
+			}
+		default: // "all"
+			filteredItems = append(filteredItems, item)
+		}
+	}
+
+	duration := time.Since(start)
+	s.logger.Info("Retrieved groceries", "total", len(groceryResp.Result), "filtered", len(filteredItems), "filter", filter, "duration", duration)
+
+	// Format results
+	var resultText strings.Builder
+	resultText.WriteString("# Grocery List\n\n")
+
+	if len(filteredItems) == 0 {
+		resultText.WriteString("No grocery items found.\n")
+	} else {
+		resultText.WriteString(fmt.Sprintf("Found %d grocery item(s):\n\n", len(filteredItems)))
+
+		// Group by aisle
+		itemsByAisle := make(map[string][]paprika.GroceryItem)
+		for _, item := range filteredItems {
+			aisle := item.Aisle
+			if aisle == "" {
+				aisle = "Other"
+			}
+			itemsByAisle[aisle] = append(itemsByAisle[aisle], item)
+		}
+
+		// Sort aisles alphabetically
+		aisles := make([]string, 0, len(itemsByAisle))
+		for aisle := range itemsByAisle {
+			aisles = append(aisles, aisle)
+		}
+		sort.Strings(aisles)
+
+		for _, aisle := range aisles {
+			items := itemsByAisle[aisle]
+			resultText.WriteString(fmt.Sprintf("## %s\n", aisle))
+
+			for _, item := range items {
+				status := "☐"
+				if item.Purchased {
+					status = "☑"
+				}
+
+				resultText.WriteString(fmt.Sprintf("%s **%s**", status, item.Ingredient))
+				if item.Quantity != "" {
+					resultText.WriteString(fmt.Sprintf(" (%s)", item.Quantity))
+				}
+				if item.Recipe != "" {
+					resultText.WriteString(fmt.Sprintf(" - for %s", item.Recipe))
+				}
+				if item.Instruction != "" {
+					resultText.WriteString(fmt.Sprintf(" _%s_", item.Instruction))
+				}
+				resultText.WriteString("\n")
+			}
+			resultText.WriteString("\n")
+		}
+	}
+
+	return mcp.NewToolResultText(resultText.String()), nil
 }

--- a/internal/mcpserver/server_test.go
+++ b/internal/mcpserver/server_test.go
@@ -1,0 +1,507 @@
+package mcpserver
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/soggycactus/paprika-3-mcp/internal/paprika"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockClient implements PaprikaClient for unit testing.
+type mockClient struct {
+	recipes      []paprika.Recipe
+	mealPlans    []paprika.MealPlan
+	groceries    []paprika.GroceryItem
+	groceryLists []paprika.GroceryList
+
+	// Track calls for assertions
+	deletedRecipeUIDs  []string
+	deletedGroceryUIDs []string
+	deletedMealUIDs    []string
+	savedGroceryItems  []paprika.GroceryItem
+}
+
+func (m *mockClient) ListRecipes(ctx context.Context) (*paprika.RecipeList, error) {
+	var result []struct {
+		UID  string `json:"uid"`
+		Hash string `json:"hash"`
+	}
+	for _, r := range m.recipes {
+		result = append(result, struct {
+			UID  string `json:"uid"`
+			Hash string `json:"hash"`
+		}{UID: r.UID, Hash: r.Hash})
+	}
+	return &paprika.RecipeList{Result: result}, nil
+}
+
+func (m *mockClient) GetRecipe(ctx context.Context, uid string) (*paprika.Recipe, error) {
+	for _, r := range m.recipes {
+		if r.UID == uid {
+			return &r, nil
+		}
+	}
+	return nil, fmt.Errorf("recipe not found: %s", uid)
+}
+
+func (m *mockClient) SaveRecipe(ctx context.Context, recipe paprika.Recipe) (*paprika.Recipe, error) {
+	return &recipe, nil
+}
+
+func (m *mockClient) DeleteRecipe(ctx context.Context, recipe paprika.Recipe) (*paprika.Recipe, error) {
+	m.deletedRecipeUIDs = append(m.deletedRecipeUIDs, recipe.UID)
+	recipe.InTrash = true
+	return &recipe, nil
+}
+
+func (m *mockClient) ListMealPlan(ctx context.Context) (*paprika.MealPlanResponse, error) {
+	return &paprika.MealPlanResponse{Result: m.mealPlans}, nil
+}
+
+func (m *mockClient) SaveMealPlan(ctx context.Context, meal paprika.MealPlan) (*paprika.MealPlan, error) {
+	meal.UID = "MOCK-MEAL-UID"
+	return &meal, nil
+}
+
+func (m *mockClient) DeleteMealPlan(ctx context.Context, uid string) error {
+	m.deletedMealUIDs = append(m.deletedMealUIDs, uid)
+	return nil
+}
+
+func (m *mockClient) ListGroceries(ctx context.Context) (*paprika.GroceryResponse, error) {
+	return &paprika.GroceryResponse{Result: m.groceries}, nil
+}
+
+func (m *mockClient) ListGroceryLists(ctx context.Context) (*paprika.GroceryListResponse, error) {
+	return &paprika.GroceryListResponse{Result: m.groceryLists}, nil
+}
+
+func (m *mockClient) SaveGroceryItem(ctx context.Context, item paprika.GroceryItem) (*paprika.GroceryItem, error) {
+	item.UID = "MOCK-GROCERY-UID"
+	m.savedGroceryItems = append(m.savedGroceryItems, item)
+	return &item, nil
+}
+
+func (m *mockClient) DeleteGroceryItem(ctx context.Context, uid string) error {
+	m.deletedGroceryUIDs = append(m.deletedGroceryUIDs, uid)
+	return nil
+}
+
+func newTestServer(mock *mockClient) *Server {
+	return &Server{
+		paprika3: mock,
+		logger:   slog.Default(),
+	}
+}
+
+func callToolRequest(args map[string]interface{}) mcp.CallToolRequest {
+	return mcp.CallToolRequest{
+		Params: struct {
+			Name      string                 `json:"name"`
+			Arguments map[string]interface{} `json:"arguments,omitempty"`
+			Meta      *struct {
+				ProgressToken mcp.ProgressToken `json:"progressToken,omitempty"`
+			} `json:"_meta,omitempty"`
+		}{
+			Arguments: args,
+		},
+	}
+}
+
+func TestMealTypeName(t *testing.T) {
+	assert.Equal(t, "Breakfast", paprika.MealTypeName(paprika.MealTypeBreakfast))
+	assert.Equal(t, "Lunch", paprika.MealTypeName(paprika.MealTypeLunch))
+	assert.Equal(t, "Dinner", paprika.MealTypeName(paprika.MealTypeDinner))
+	assert.Equal(t, "Meal", paprika.MealTypeName(99))
+}
+
+func TestListMealPlan_DateFiltering(t *testing.T) {
+	mock := &mockClient{
+		mealPlans: []paprika.MealPlan{
+			{UID: "1", Name: "Monday Dinner", Date: "2025-03-10 00:00:00", Type: paprika.MealTypeDinner},
+			{UID: "2", Name: "Tuesday Lunch", Date: "2025-03-11 00:00:00", Type: paprika.MealTypeLunch},
+			{UID: "3", Name: "Wednesday Breakfast", Date: "2025-03-12 00:00:00", Type: paprika.MealTypeBreakfast},
+			{UID: "4", Name: "Deleted Meal", Date: "2025-03-11 00:00:00", Type: paprika.MealTypeDinner, Deleted: true},
+		},
+	}
+	s := newTestServer(mock)
+	ctx := context.Background()
+
+	t.Run("no filters returns all non-deleted", func(t *testing.T) {
+		result, err := s.listMealPlan(ctx, callToolRequest(map[string]interface{}{}))
+		require.NoError(t, err)
+		text := result.Content[0].(mcp.TextContent).Text
+		assert.Contains(t, text, "Monday Dinner")
+		assert.Contains(t, text, "Tuesday Lunch")
+		assert.Contains(t, text, "Wednesday Breakfast")
+		assert.NotContains(t, text, "Deleted Meal")
+	})
+
+	t.Run("start_date filters correctly", func(t *testing.T) {
+		result, err := s.listMealPlan(ctx, callToolRequest(map[string]interface{}{
+			"start_date": "2025-03-11",
+		}))
+		require.NoError(t, err)
+		text := result.Content[0].(mcp.TextContent).Text
+		assert.NotContains(t, text, "Monday Dinner")
+		assert.Contains(t, text, "Tuesday Lunch")
+		assert.Contains(t, text, "Wednesday Breakfast")
+	})
+
+	t.Run("end_date filters correctly", func(t *testing.T) {
+		result, err := s.listMealPlan(ctx, callToolRequest(map[string]interface{}{
+			"end_date": "2025-03-11",
+		}))
+		require.NoError(t, err)
+		text := result.Content[0].(mcp.TextContent).Text
+		assert.Contains(t, text, "Monday Dinner")
+		assert.Contains(t, text, "Tuesday Lunch")
+		assert.NotContains(t, text, "Wednesday Breakfast")
+	})
+
+	t.Run("exact date match includes the meal", func(t *testing.T) {
+		result, err := s.listMealPlan(ctx, callToolRequest(map[string]interface{}{
+			"start_date": "2025-03-10",
+			"end_date":   "2025-03-10",
+		}))
+		require.NoError(t, err)
+		text := result.Content[0].(mcp.TextContent).Text
+		assert.Contains(t, text, "Monday Dinner")
+		assert.NotContains(t, text, "Tuesday Lunch")
+	})
+
+	t.Run("deleted meals are excluded", func(t *testing.T) {
+		result, err := s.listMealPlan(ctx, callToolRequest(map[string]interface{}{
+			"start_date": "2025-03-11",
+			"end_date":   "2025-03-11",
+		}))
+		require.NoError(t, err)
+		text := result.Content[0].(mcp.TextContent).Text
+		assert.Contains(t, text, "Tuesday Lunch")
+		assert.NotContains(t, text, "Deleted Meal")
+	})
+}
+
+func TestListGroceries_PurchaseFilter(t *testing.T) {
+	mock := &mockClient{
+		groceries: []paprika.GroceryItem{
+			{UID: "1", Ingredient: "Milk", Purchased: false, Aisle: "Dairy"},
+			{UID: "2", Ingredient: "Eggs", Purchased: true, Aisle: "Dairy"},
+			{UID: "3", Ingredient: "Bread", Purchased: false, Aisle: "Bakery"},
+			{UID: "4", Ingredient: "Deleted Item", Purchased: false, Deleted: true},
+		},
+	}
+	s := newTestServer(mock)
+	ctx := context.Background()
+
+	t.Run("all returns non-deleted items", func(t *testing.T) {
+		result, err := s.listGroceries(ctx, callToolRequest(map[string]interface{}{
+			"filter": "all",
+		}))
+		require.NoError(t, err)
+		text := result.Content[0].(mcp.TextContent).Text
+		assert.Contains(t, text, "Milk")
+		assert.Contains(t, text, "Eggs")
+		assert.Contains(t, text, "Bread")
+		assert.NotContains(t, text, "Deleted Item")
+	})
+
+	t.Run("purchased filter", func(t *testing.T) {
+		result, err := s.listGroceries(ctx, callToolRequest(map[string]interface{}{
+			"filter": "purchased",
+		}))
+		require.NoError(t, err)
+		text := result.Content[0].(mcp.TextContent).Text
+		assert.NotContains(t, text, "Milk")
+		assert.Contains(t, text, "Eggs")
+		assert.NotContains(t, text, "Bread")
+	})
+
+	t.Run("unpurchased filter", func(t *testing.T) {
+		result, err := s.listGroceries(ctx, callToolRequest(map[string]interface{}{
+			"filter": "unpurchased",
+		}))
+		require.NoError(t, err)
+		text := result.Content[0].(mcp.TextContent).Text
+		assert.Contains(t, text, "Milk")
+		assert.NotContains(t, text, "Eggs")
+		assert.Contains(t, text, "Bread")
+	})
+
+	t.Run("default filter is all", func(t *testing.T) {
+		result, err := s.listGroceries(ctx, callToolRequest(map[string]interface{}{}))
+		require.NoError(t, err)
+		text := result.Content[0].(mcp.TextContent).Text
+		assert.Contains(t, text, "3 grocery item(s)")
+	})
+
+	t.Run("items grouped by aisle and aisles sorted", func(t *testing.T) {
+		result, err := s.listGroceries(ctx, callToolRequest(map[string]interface{}{}))
+		require.NoError(t, err)
+		text := result.Content[0].(mcp.TextContent).Text
+		// Aisles should appear in alphabetical order: Bakery before Dairy
+		bakeryIdx := strings.Index(text, "## Bakery")
+		dairyIdx := strings.Index(text, "## Dairy")
+		require.NotEqual(t, -1, bakeryIdx, "should have Bakery aisle")
+		require.NotEqual(t, -1, dairyIdx, "should have Dairy aisle")
+		assert.Less(t, bakeryIdx, dairyIdx, "Bakery should appear before Dairy")
+	})
+
+	t.Run("items without aisle grouped under Other", func(t *testing.T) {
+		mockWithNoAisle := &mockClient{
+			groceries: []paprika.GroceryItem{
+				{UID: "1", Ingredient: "Mystery Item", Aisle: ""},
+			},
+		}
+		s2 := newTestServer(mockWithNoAisle)
+		result, err := s2.listGroceries(ctx, callToolRequest(map[string]interface{}{}))
+		require.NoError(t, err)
+		text := result.Content[0].(mcp.TextContent).Text
+		assert.Contains(t, text, "## Other")
+		assert.Contains(t, text, "Mystery Item")
+	})
+}
+
+func TestListRecipes(t *testing.T) {
+	mock := &mockClient{
+		recipes: []paprika.Recipe{
+			{UID: "1", Name: "Chicken Tikka Masala", Ingredients: "chicken, yogurt, spices", Description: "Indian curry"},
+			{UID: "2", Name: "Spaghetti Bolognese", Ingredients: "pasta, beef, tomatoes", Description: "Italian classic"},
+			{UID: "3", Name: "Chicken Caesar Salad", Ingredients: "chicken, romaine, parmesan", Description: "Light lunch"},
+			{UID: "4", Name: "Trashed Recipe", Ingredients: "nothing", Description: "Gone", InTrash: true},
+		},
+	}
+	s := newTestServer(mock)
+	ctx := context.Background()
+
+	t.Run("returns all non-trashed sorted by name", func(t *testing.T) {
+		result, err := s.listRecipes(ctx, callToolRequest(map[string]interface{}{}))
+		require.NoError(t, err)
+		text := result.Content[0].(mcp.TextContent).Text
+		assert.Contains(t, text, "Chicken Caesar Salad")
+		assert.Contains(t, text, "Chicken Tikka Masala")
+		assert.Contains(t, text, "Spaghetti Bolognese")
+		assert.NotContains(t, text, "Trashed Recipe")
+		// Verify alphabetical order
+		caesarIdx := strings.Index(text, "Chicken Caesar Salad")
+		tikkaIdx := strings.Index(text, "Chicken Tikka Masala")
+		spaghettiIdx := strings.Index(text, "Spaghetti Bolognese")
+		assert.Less(t, caesarIdx, tikkaIdx)
+		assert.Less(t, tikkaIdx, spaghettiIdx)
+	})
+
+	t.Run("limit caps results", func(t *testing.T) {
+		result, err := s.listRecipes(ctx, callToolRequest(map[string]interface{}{
+			"limit": float64(2),
+		}))
+		require.NoError(t, err)
+		text := result.Content[0].(mcp.TextContent).Text
+		assert.Contains(t, text, "Found 2 recipe(s)")
+	})
+}
+
+func TestSearchRecipes(t *testing.T) {
+	mock := &mockClient{
+		recipes: []paprika.Recipe{
+			{UID: "1", Name: "Chicken Tikka Masala", Ingredients: "chicken, yogurt, spices", Description: "Indian curry"},
+			{UID: "2", Name: "Spaghetti Bolognese", Ingredients: "pasta, beef, tomatoes", Description: "Italian classic"},
+			{UID: "3", Name: "Chicken Caesar Salad", Ingredients: "chicken, romaine, parmesan", Description: "Light lunch"},
+			{UID: "4", Name: "Trashed Recipe", Ingredients: "nothing", Description: "Gone", InTrash: true},
+		},
+	}
+	s := newTestServer(mock)
+	ctx := context.Background()
+
+	t.Run("empty query returns error", func(t *testing.T) {
+		_, err := s.searchRecipes(ctx, callToolRequest(map[string]interface{}{}))
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "query is required")
+	})
+
+	t.Run("keyword search matches name", func(t *testing.T) {
+		result, err := s.searchRecipes(ctx, callToolRequest(map[string]interface{}{
+			"query": "spaghetti",
+		}))
+		require.NoError(t, err)
+		text := result.Content[0].(mcp.TextContent).Text
+		assert.Contains(t, text, "Spaghetti Bolognese")
+		assert.NotContains(t, text, "Chicken")
+	})
+
+	t.Run("keyword search matches ingredients", func(t *testing.T) {
+		result, err := s.searchRecipes(ctx, callToolRequest(map[string]interface{}{
+			"query": "romaine",
+		}))
+		require.NoError(t, err)
+		text := result.Content[0].(mcp.TextContent).Text
+		assert.Contains(t, text, "Chicken Caesar Salad")
+		assert.NotContains(t, text, "Tikka")
+	})
+
+	t.Run("search is case insensitive", func(t *testing.T) {
+		result, err := s.searchRecipes(ctx, callToolRequest(map[string]interface{}{
+			"query": "CHICKEN",
+		}))
+		require.NoError(t, err)
+		text := result.Content[0].(mcp.TextContent).Text
+		assert.Contains(t, text, "Chicken Tikka Masala")
+		assert.Contains(t, text, "Chicken Caesar Salad")
+	})
+
+	t.Run("limit caps results", func(t *testing.T) {
+		result, err := s.searchRecipes(ctx, callToolRequest(map[string]interface{}{
+			"query": "chicken",
+			"limit": float64(1),
+		}))
+		require.NoError(t, err)
+		text := result.Content[0].(mcp.TextContent).Text
+		assert.Contains(t, text, "Found 1 recipe(s)")
+	})
+
+	t.Run("multi-word search matches all words", func(t *testing.T) {
+		result, err := s.searchRecipes(ctx, callToolRequest(map[string]interface{}{
+			"query": "chicken yogurt",
+		}))
+		require.NoError(t, err)
+		text := result.Content[0].(mcp.TextContent).Text
+		assert.Contains(t, text, "Chicken Tikka Masala")
+		assert.NotContains(t, text, "Caesar Salad")
+	})
+
+	t.Run("multi-word search requires all words", func(t *testing.T) {
+		result, err := s.searchRecipes(ctx, callToolRequest(map[string]interface{}{
+			"query": "chicken tomatoes",
+		}))
+		require.NoError(t, err)
+		text := result.Content[0].(mcp.TextContent).Text
+		assert.Contains(t, text, "No recipes found matching your search")
+	})
+
+	t.Run("no match returns message", func(t *testing.T) {
+		result, err := s.searchRecipes(ctx, callToolRequest(map[string]interface{}{
+			"query": "nonexistent",
+		}))
+		require.NoError(t, err)
+		text := result.Content[0].(mcp.TextContent).Text
+		assert.Contains(t, text, "No recipes found matching your search")
+	})
+}
+
+func TestRemoveGroceryItem(t *testing.T) {
+	mock := &mockClient{
+		groceries: []paprika.GroceryItem{
+			{UID: "1", Ingredient: "Whole Milk", Name: "Whole Milk"},
+			{UID: "2", Ingredient: "Almond Milk", Name: "Almond Milk"},
+			{UID: "3", Ingredient: "Eggs", Name: "Eggs"},
+		},
+	}
+	s := newTestServer(mock)
+	ctx := context.Background()
+
+	t.Run("exact match removes item", func(t *testing.T) {
+		mock.deletedGroceryUIDs = nil
+		result, err := s.removeGroceryItem(ctx, callToolRequest(map[string]interface{}{
+			"item_name": "Eggs",
+		}))
+		require.NoError(t, err)
+		text := result.Content[0].(mcp.TextContent).Text
+		assert.Contains(t, text, "Removed **Eggs**")
+		assert.Equal(t, []string{"3"}, mock.deletedGroceryUIDs)
+	})
+
+	t.Run("partial match finds items", func(t *testing.T) {
+		mock.deletedGroceryUIDs = nil
+		result, err := s.removeGroceryItem(ctx, callToolRequest(map[string]interface{}{
+			"item_name": "milk",
+		}))
+		require.NoError(t, err)
+		text := result.Content[0].(mcp.TextContent).Text
+		// Should remove first match (Whole Milk) and report both
+		assert.Contains(t, text, "Found 2 items matching")
+		assert.Equal(t, []string{"1"}, mock.deletedGroceryUIDs)
+	})
+
+	t.Run("no match returns message", func(t *testing.T) {
+		mock.deletedGroceryUIDs = nil
+		result, err := s.removeGroceryItem(ctx, callToolRequest(map[string]interface{}{
+			"item_name": "butter",
+		}))
+		require.NoError(t, err)
+		text := result.Content[0].(mcp.TextContent).Text
+		assert.Contains(t, text, "No Items Found")
+		assert.Empty(t, mock.deletedGroceryUIDs)
+	})
+
+	t.Run("case insensitive", func(t *testing.T) {
+		mock.deletedGroceryUIDs = nil
+		result, err := s.removeGroceryItem(ctx, callToolRequest(map[string]interface{}{
+			"item_name": "EGGS",
+		}))
+		require.NoError(t, err)
+		text := result.Content[0].(mcp.TextContent).Text
+		assert.Contains(t, text, "Removed **Eggs**")
+		assert.Equal(t, []string{"3"}, mock.deletedGroceryUIDs)
+	})
+}
+
+func TestListGroceryLists_FiltersDeleted(t *testing.T) {
+	mock := &mockClient{
+		groceryLists: []paprika.GroceryList{
+			{UID: "1", Name: "My List", IsDefault: true},
+			{UID: "2", Name: "Trader Joe's", IsDefault: false},
+			{UID: "3", Name: "Old List", IsDefault: false, Deleted: true},
+		},
+	}
+	s := newTestServer(mock)
+	ctx := context.Background()
+
+	result, err := s.listGroceryLists(ctx, callToolRequest(map[string]interface{}{}))
+	require.NoError(t, err)
+	text := result.Content[0].(mcp.TextContent).Text
+	assert.Contains(t, text, "My List")
+	assert.Contains(t, text, "(default)")
+	assert.Contains(t, text, "Trader Joe's")
+	assert.NotContains(t, text, "Old List")
+}
+
+func TestDeleteRecipe(t *testing.T) {
+	mock := &mockClient{
+		recipes: []paprika.Recipe{
+			{UID: "recipe-1", Name: "Test Recipe", Ingredients: "flour", Directions: "mix"},
+			{UID: "recipe-2", Name: "Other Recipe", Ingredients: "sugar", Directions: "bake"},
+		},
+	}
+	s := newTestServer(mock)
+	ctx := context.Background()
+
+	t.Run("deletes recipe by UID", func(t *testing.T) {
+		result, err := s.deleteRecipe(ctx, callToolRequest(map[string]interface{}{
+			"uid": "recipe-1",
+		}))
+		require.NoError(t, err)
+		text := result.Content[0].(mcp.TextContent).Text
+		assert.Contains(t, text, "Test Recipe")
+		assert.Contains(t, text, "trash")
+		assert.Equal(t, []string{"recipe-1"}, mock.deletedRecipeUIDs)
+	})
+
+	t.Run("returns error for missing UID", func(t *testing.T) {
+		_, err := s.deleteRecipe(ctx, callToolRequest(map[string]interface{}{}))
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "uid is required")
+	})
+
+	t.Run("returns error for unknown UID", func(t *testing.T) {
+		_, err := s.deleteRecipe(ctx, callToolRequest(map[string]interface{}{
+			"uid": "nonexistent",
+		}))
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to get recipe")
+	})
+}

--- a/internal/paprika/client.go
+++ b/internal/paprika/client.go
@@ -5,6 +5,7 @@ import (
 	"compress/gzip"
 	"context"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -38,6 +39,73 @@ func (r *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	return r.transport.RoundTrip(req)
 }
 
+// retryTransport wraps an http.RoundTripper with retry logic for 429 and 5xx responses.
+// It uses exponential backoff and respects the Retry-After header.
+type retryTransport struct {
+	transport  http.RoundTripper
+	maxRetries int
+	baseDelay  time.Duration
+}
+
+func (t *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Read body upfront so we can replay it on retries
+	var bodyBytes []byte
+	if req.Body != nil {
+		var err error
+		bodyBytes, err = io.ReadAll(req.Body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read request body: %w", err)
+		}
+		req.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+	}
+
+	var resp *http.Response
+	var err error
+
+	for attempt := 0; attempt <= t.maxRetries; attempt++ {
+		if bodyBytes != nil && attempt > 0 {
+			req.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+		}
+
+		resp, err = t.transport.RoundTrip(req)
+		if err != nil {
+			return nil, err // network errors are not retried
+		}
+
+		// Don't retry on success or client errors (except 429)
+		if resp.StatusCode < 429 || (resp.StatusCode > 429 && resp.StatusCode < 500) {
+			return resp, nil
+		}
+
+		// Last attempt — return whatever we got
+		if attempt == t.maxRetries {
+			return resp, nil
+		}
+
+		// Calculate delay: use Retry-After header if present, otherwise exponential backoff
+		delay := t.baseDelay * (1 << attempt)
+		if resp.StatusCode == 429 {
+			if ra := resp.Header.Get("Retry-After"); ra != "" {
+				if seconds, parseErr := time.ParseDuration(ra + "s"); parseErr == nil {
+					delay = seconds
+				}
+			}
+		}
+
+		// Drain and close the response body before retrying
+		io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+
+		select {
+		case <-req.Context().Done():
+			return nil, req.Context().Err()
+		case <-time.After(delay):
+		}
+	}
+
+	return resp, nil
+}
+
 func userAgent(version string) string {
 	return fmt.Sprintf("paprika-3-mcp/%s (golang; %s)", version, runtime.Version())
 }
@@ -67,13 +135,17 @@ func NewClient(username, password, version string, logger *slog.Logger) (*Client
 		return nil, fmt.Errorf("failed to login: %w", err)
 	}
 
-	client.Transport = &roundTripper{
-		transport: t,
-		headers: map[string]string{
-			"Accept":        "*/*",
-			"Authorization": fmt.Sprintf("Bearer %s", token),
-			"Connection":    "keep-alive",
-			"User-Agent":    userAgent(version),
+	client.Transport = &retryTransport{
+		maxRetries: 3,
+		baseDelay:  500 * time.Millisecond,
+		transport: &roundTripper{
+			transport: t,
+			headers: map[string]string{
+				"Accept":        "*/*",
+				"Authorization": fmt.Sprintf("Bearer %s", token),
+				"Connection":    "keep-alive",
+				"User-Agent":    userAgent(version),
+			},
 		},
 	}
 
@@ -83,14 +155,18 @@ func NewClient(username, password, version string, logger *slog.Logger) (*Client
 	}
 
 	return &Client{
-		client: client,
-		logger: l,
+		client:   client,
+		logger:   l,
+		username: username,
+		password: password,
 	}, nil
 }
 
 type Client struct {
-	client *http.Client
-	logger *slog.Logger
+	client   *http.Client
+	logger   *slog.Logger
+	username string
+	password string
 }
 
 type loginResponse struct {
@@ -186,6 +262,60 @@ func (c *Client) ListRecipes(ctx context.Context) (*RecipeList, error) {
 
 	c.logger.Info("found recipes", "count", len(recipeList.Result))
 	return &recipeList, nil
+}
+
+const (
+	MealTypeBreakfast = 0
+	MealTypeLunch     = 1
+	MealTypeDinner    = 2
+)
+
+// MealTypeName returns a human-readable name for a meal type constant.
+func MealTypeName(t int) string {
+	switch t {
+	case MealTypeBreakfast:
+		return "Breakfast"
+	case MealTypeLunch:
+		return "Lunch"
+	case MealTypeDinner:
+		return "Dinner"
+	default:
+		return "Meal"
+	}
+}
+
+type MealPlan struct {
+	UID       string `json:"uid"`
+	RecipeUID string `json:"recipe_uid"`
+	Date      string `json:"date"`
+	Type      int    `json:"type"`
+	Name      string `json:"name"`
+	OrderFlag int    `json:"order_flag"`
+	Deleted   bool   `json:"deleted"`
+}
+
+type MealPlanResponse struct {
+	Result []MealPlan `json:"result"`
+}
+
+type GroceryItem struct {
+	UID         string `json:"uid"`
+	RecipeUID   string `json:"recipe_uid"`
+	Name        string `json:"name"`
+	OrderFlag   int    `json:"order_flag"`
+	Purchased   bool   `json:"purchased"`
+	Aisle       string `json:"aisle"`
+	Ingredient  string `json:"ingredient"`
+	Recipe      string `json:"recipe"`
+	Instruction string `json:"instruction"`
+	Quantity    string `json:"quantity"`
+	AisleUID    string `json:"aisle_uid"`
+	ListUID     string `json:"list_uid"`
+	Deleted     bool   `json:"deleted"` // Soft delete flag (like MealPlan)
+}
+
+type GroceryResponse struct {
+	Result []GroceryItem `json:"result"`
 }
 
 type Recipe struct {
@@ -344,26 +474,6 @@ func (r *Recipe) updateHash() error {
 	return nil
 }
 
-func (r *Recipe) asGzip() ([]byte, error) {
-	jsonBytes, err := json.Marshal(r)
-	if err != nil {
-		return nil, err
-	}
-
-	var buf bytes.Buffer
-	writer := gzip.NewWriter(&buf)
-	_, err = writer.Write(jsonBytes)
-	if err != nil {
-		writer.Close()
-		return nil, err
-	}
-	if err := writer.Close(); err != nil {
-		return nil, err
-	}
-
-	return buf.Bytes(), nil
-}
-
 type GetRecipeResponse struct {
 	Result Recipe `json:"result"`
 }
@@ -413,74 +523,17 @@ func (c *Client) DeleteRecipe(ctx context.Context, recipe Recipe) (*Recipe, erro
 // SaveRecipe saves a recipe to the Paprika API. If the recipe already exists, it will be updated.
 // If the recipe does not exist, it will be created.
 func (c *Client) SaveRecipe(ctx context.Context, recipe Recipe) (*Recipe, error) {
-	// set the created timestamp
 	recipe.updateCreated()
-	// generate a new UUID if one doesn't exist
 	recipe.generateUUID()
-	// generate a hash of the recipe object
 	if err := recipe.updateHash(); err != nil {
 		return nil, err
 	}
 
-	// gzip the recipe
-	fileData, err := recipe.asGzip()
-	if err != nil {
-		return nil, err
-	}
-
-	// Create a multipart form request
-	var body bytes.Buffer
-	writer := multipart.NewWriter(&body)
-	part, err := writer.CreateFormFile("data", "data")
-	if err != nil {
-		c.logger.Error("failed to create form file", "error", err)
-		return nil, err
-	}
-
-	// Write the gzipped JSON data to the form file
-	if _, err := part.Write(fileData); err != nil {
-		c.logger.Error("failed to write gzipped JSON data", "error", err)
-		return nil, err
-	}
-	if err := writer.Close(); err != nil {
-		c.logger.Error("failed to close multipart writer", "error", err)
-		return nil, err
-	}
-
-	// Create the HTTP request
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("https://paprikaapp.com/api/v2/sync/recipe/%s/", recipe.UID), &body)
-	if err != nil {
-		c.logger.Error("failed to create request", "error", err)
-		return nil, err
-	}
-	req.Header.Set("Content-Type", writer.FormDataContentType())
-	req.ContentLength = int64(body.Len())
-
-	resp, err := c.client.Do(req)
-	if err != nil {
-		c.logger.Error("failed to create recipe", "error", err)
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		c.logger.Error("failed to create recipe", "status", resp.Status)
-		return nil, fmt.Errorf("failed to create recipe: %s", resp.Status)
-	}
-
-	rawBytes, err := io.ReadAll(resp.Body)
-	if err != nil {
-		c.logger.Error("failed to read response body", "error", err)
-		return nil, err
-	}
-
-	if err := isErrorResponse(rawBytes); err != nil {
-		c.logger.Error("failed to create recipe", "error", err)
-		return nil, err
+	if err := c.postV2(ctx, fmt.Sprintf("https://paprikaapp.com/api/v2/sync/recipe/%s/", recipe.UID), recipe); err != nil {
+		return nil, fmt.Errorf("failed to save recipe: %w", err)
 	}
 
 	defer c.notify(ctx)
-
 	return &recipe, nil
 }
 
@@ -524,5 +577,331 @@ func isErrorResponse(body []byte) error {
 		return fmt.Errorf("error: %s (code: %d)", errResp.Error.Message, errResp.Error.Code)
 	}
 
+	return nil
+}
+
+// postV2 sends a gzipped JSON payload to a V2 API endpoint using multipart form encoding.
+// Uses the Bearer token set on the HTTP client's roundTripper.
+func (c *Client) postV2(ctx context.Context, endpoint string, v interface{}) error {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Errorf("failed to marshal data: %w", err)
+	}
+
+	// Gzip the data
+	var gzipBuf bytes.Buffer
+	gzWriter := gzip.NewWriter(&gzipBuf)
+	if _, err := gzWriter.Write(data); err != nil {
+		gzWriter.Close()
+		return fmt.Errorf("failed to gzip data: %w", err)
+	}
+	if err := gzWriter.Close(); err != nil {
+		return fmt.Errorf("failed to close gzip writer: %w", err)
+	}
+
+	// Build multipart form
+	var body bytes.Buffer
+	mpWriter := multipart.NewWriter(&body)
+	part, err := mpWriter.CreateFormFile("data", "data")
+	if err != nil {
+		return fmt.Errorf("failed to create form file: %w", err)
+	}
+	if _, err := part.Write(gzipBuf.Bytes()); err != nil {
+		return fmt.Errorf("failed to write form data: %w", err)
+	}
+	if err := mpWriter.Close(); err != nil {
+		return fmt.Errorf("failed to close multipart writer: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, &body)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", mpWriter.FormDataContentType())
+	req.ContentLength = int64(body.Len())
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	rawBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status %s: %s", resp.Status, string(rawBytes))
+	}
+
+	if err := isErrorResponse(rawBytes); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// postV1 sends a gzipped JSON payload to a V1 API endpoint using Basic Auth and multipart form encoding.
+// The V1 API is required for meal and grocery writes — the V2 sync endpoints only exist for recipes.
+func (c *Client) postV1(ctx context.Context, endpoint string, data []byte) error {
+	// Gzip the data
+	var gzipBuf bytes.Buffer
+	gzWriter := gzip.NewWriter(&gzipBuf)
+	if _, err := gzWriter.Write(data); err != nil {
+		gzWriter.Close()
+		return fmt.Errorf("failed to gzip data: %w", err)
+	}
+	if err := gzWriter.Close(); err != nil {
+		return fmt.Errorf("failed to close gzip writer: %w", err)
+	}
+
+	// Build multipart form
+	var body bytes.Buffer
+	mpWriter := multipart.NewWriter(&body)
+	part, err := mpWriter.CreateFormFile("data", "data")
+	if err != nil {
+		return fmt.Errorf("failed to create form file: %w", err)
+	}
+	if _, err := part.Write(gzipBuf.Bytes()); err != nil {
+		return fmt.Errorf("failed to write form data: %w", err)
+	}
+	if err := mpWriter.Close(); err != nil {
+		return fmt.Errorf("failed to close multipart writer: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, &body)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	// V1 API requires Basic Auth instead of Bearer token
+	credentials := base64.StdEncoding.EncodeToString([]byte(c.username + ":" + c.password))
+	req.Header.Set("Authorization", "Basic "+credentials)
+	req.Header.Set("Content-Type", mpWriter.FormDataContentType())
+	req.ContentLength = int64(body.Len())
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	rawBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status %s: %s", resp.Status, string(rawBytes))
+	}
+
+	if err := isErrorResponse(rawBytes); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+type GroceryList struct {
+	UID            string `json:"uid"`
+	Name           string `json:"name"`
+	OrderFlag      int    `json:"order_flag"`
+	IsDefault      bool   `json:"is_default"`
+	RemindersList  string `json:"reminders_list"`
+	Deleted        bool   `json:"deleted"`
+}
+
+type GroceryListResponse struct {
+	Result []GroceryList `json:"result"`
+}
+
+// ListGroceryLists retrieves all grocery lists from the Paprika API
+func (c *Client) ListGroceryLists(ctx context.Context) (*GroceryListResponse, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://paprikaapp.com/api/v2/sync/grocerylists", nil)
+	if err != nil {
+		c.logger.Error("failed to create request", "error", err)
+		return nil, err
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		c.logger.Error("failed to get grocery lists", "error", err)
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		c.logger.Error("failed to get grocery lists", "status", resp.Status)
+		return nil, fmt.Errorf("failed to get grocery lists: %s", resp.Status)
+	}
+
+	rawBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		c.logger.Error("failed to read response body", "error", err)
+		return nil, err
+	}
+
+	var groceryListResp GroceryListResponse
+	if err := json.Unmarshal(rawBytes, &groceryListResp); err != nil {
+		c.logger.Error("failed to unmarshal grocery lists response", "error", err)
+		return nil, err
+	}
+
+	c.logger.Info("Retrieved grocery lists", "count", len(groceryListResp.Result))
+	return &groceryListResp, nil
+}
+
+// ListMealPlan retrieves meal plan data from Paprika API
+func (c *Client) ListMealPlan(ctx context.Context) (*MealPlanResponse, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://paprikaapp.com/api/v2/sync/meals", nil)
+	if err != nil {
+		c.logger.Error("failed to create request", "error", err)
+		return nil, err
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		c.logger.Error("failed to get meals", "error", err)
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		c.logger.Error("failed to get meals", "status", resp.Status)
+		return nil, fmt.Errorf("failed to get meals: %s", resp.Status)
+	}
+
+	rawBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		c.logger.Error("failed to read response body", "error", err)
+		return nil, err
+	}
+
+	var mealPlanResp MealPlanResponse
+	if err := json.Unmarshal(rawBytes, &mealPlanResp); err != nil {
+		c.logger.Error("failed to unmarshal meal plan response", "error", err)
+		return nil, err
+	}
+
+	c.logger.Info("Retrieved meal plan", "count", len(mealPlanResp.Result))
+	return &mealPlanResp, nil
+}
+
+// ListGroceries retrieves grocery list data from Paprika API
+func (c *Client) ListGroceries(ctx context.Context) (*GroceryResponse, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://paprikaapp.com/api/v2/sync/groceries", nil)
+	if err != nil {
+		c.logger.Error("failed to create request", "error", err)
+		return nil, err
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		c.logger.Error("failed to get groceries", "error", err)
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		c.logger.Error("failed to get groceries", "status", resp.Status)
+		return nil, fmt.Errorf("failed to get groceries: %s", resp.Status)
+	}
+
+	rawBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		c.logger.Error("failed to read response body", "error", err)
+		return nil, err
+	}
+
+	var groceryResp GroceryResponse
+	if err := json.Unmarshal(rawBytes, &groceryResp); err != nil {
+		c.logger.Error("failed to unmarshal grocery response", "error", err)
+		return nil, err
+	}
+
+	c.logger.Info("Retrieved groceries", "count", len(groceryResp.Result))
+	return &groceryResp, nil
+}
+
+// SaveMealPlan saves a meal plan entry to Paprika API using V1 API.
+// The V2 sync endpoints don't support meal writes.
+func (c *Client) SaveMealPlan(ctx context.Context, meal MealPlan) (*MealPlan, error) {
+	if meal.UID == "" {
+		meal.UID = strings.ToUpper(uuid.New().String())
+	}
+	meal.Deleted = false
+
+	c.logger.Info("Saving meal", "uid", meal.UID, "name", meal.Name, "date", meal.Date, "type", meal.Type)
+
+	data, err := json.Marshal([]MealPlan{meal})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal meal: %w", err)
+	}
+
+	if err := c.postV1(ctx, "https://paprikaapp.com/api/v1/sync/meals/", data); err != nil {
+		return nil, fmt.Errorf("failed to save meal: %w", err)
+	}
+
+	defer c.notify(ctx)
+	return &meal, nil
+}
+
+// DeleteMealPlan soft-deletes a meal plan entry by setting the deleted flag
+func (c *Client) DeleteMealPlan(ctx context.Context, uid string) error {
+	c.logger.Info("Soft-deleting meal", "uid", uid)
+
+	data, err := json.Marshal([]MealPlan{{UID: uid, Deleted: true}})
+	if err != nil {
+		return fmt.Errorf("failed to marshal meal deletion: %w", err)
+	}
+
+	if err := c.postV1(ctx, "https://paprikaapp.com/api/v1/sync/meals/", data); err != nil {
+		return fmt.Errorf("failed to delete meal: %w", err)
+	}
+
+	defer c.notify(ctx)
+	return nil
+}
+
+// SaveGroceryItem saves a grocery item to Paprika API using V1 API.
+// The V2 sync endpoints don't support grocery writes.
+func (c *Client) SaveGroceryItem(ctx context.Context, item GroceryItem) (*GroceryItem, error) {
+	if item.UID == "" {
+		item.UID = strings.ToUpper(uuid.New().String())
+	}
+	if item.Name == "" {
+		item.Name = item.Ingredient
+	}
+
+	c.logger.Info("Saving grocery item", "uid", item.UID, "ingredient", item.Ingredient, "aisle", item.Aisle)
+
+	data, err := json.Marshal([]GroceryItem{item})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal grocery item: %w", err)
+	}
+
+	if err := c.postV1(ctx, "https://paprikaapp.com/api/v1/sync/groceries/", data); err != nil {
+		return nil, fmt.Errorf("failed to save grocery item: %w", err)
+	}
+
+	defer c.notify(ctx)
+	return &item, nil
+}
+
+// DeleteGroceryItem soft-deletes a grocery item by setting the deleted flag
+func (c *Client) DeleteGroceryItem(ctx context.Context, uid string) error {
+	c.logger.Info("Soft-deleting grocery item", "uid", uid)
+
+	data, err := json.Marshal([]GroceryItem{{UID: uid, Deleted: true}})
+	if err != nil {
+		return fmt.Errorf("failed to marshal grocery item deletion: %w", err)
+	}
+
+	if err := c.postV1(ctx, "https://paprikaapp.com/api/v1/sync/groceries/", data); err != nil {
+		return fmt.Errorf("failed to delete grocery item: %w", err)
+	}
+
+	defer c.notify(ctx)
 	return nil
 }

--- a/internal/paprika/client.go
+++ b/internal/paprika/client.go
@@ -522,6 +522,13 @@ func (c *Client) DeleteRecipe(ctx context.Context, recipe Recipe) (*Recipe, erro
 // SaveRecipe saves a recipe to the Paprika API. If the recipe already exists, it will be updated.
 // If the recipe does not exist, it will be created.
 func (c *Client) SaveRecipe(ctx context.Context, recipe Recipe) (*Recipe, error) {
+	// Categories must serialize as [] not null. A nil []string marshals to "null",
+	// which breaks the Paprika .NET clients' sync deserializer with
+	// "Value cannot be null. Parameter name: collection" (see issue #7).
+	// Normalize here so every caller is protected, not just the create/update handlers.
+	if recipe.Categories == nil {
+		recipe.Categories = []string{}
+	}
 	recipe.updateCreated()
 	recipe.generateUUID()
 	if err := recipe.updateHash(); err != nil {

--- a/internal/paprika/client.go
+++ b/internal/paprika/client.go
@@ -5,7 +5,6 @@ import (
 	"compress/gzip"
 	"context"
 	"crypto/sha256"
-	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -642,66 +641,7 @@ func (c *Client) postV2(ctx context.Context, endpoint string, v interface{}) err
 	return nil
 }
 
-// postV1 sends a gzipped JSON payload to a V1 API endpoint using Basic Auth and multipart form encoding.
-// The V1 API is required for meal and grocery writes — the V2 sync endpoints only exist for recipes.
-func (c *Client) postV1(ctx context.Context, endpoint string, data []byte) error {
-	// Gzip the data
-	var gzipBuf bytes.Buffer
-	gzWriter := gzip.NewWriter(&gzipBuf)
-	if _, err := gzWriter.Write(data); err != nil {
-		gzWriter.Close()
-		return fmt.Errorf("failed to gzip data: %w", err)
-	}
-	if err := gzWriter.Close(); err != nil {
-		return fmt.Errorf("failed to close gzip writer: %w", err)
-	}
 
-	// Build multipart form
-	var body bytes.Buffer
-	mpWriter := multipart.NewWriter(&body)
-	part, err := mpWriter.CreateFormFile("data", "data")
-	if err != nil {
-		return fmt.Errorf("failed to create form file: %w", err)
-	}
-	if _, err := part.Write(gzipBuf.Bytes()); err != nil {
-		return fmt.Errorf("failed to write form data: %w", err)
-	}
-	if err := mpWriter.Close(); err != nil {
-		return fmt.Errorf("failed to close multipart writer: %w", err)
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, &body)
-	if err != nil {
-		return fmt.Errorf("failed to create request: %w", err)
-	}
-
-	// V1 API requires Basic Auth instead of Bearer token
-	credentials := base64.StdEncoding.EncodeToString([]byte(c.username + ":" + c.password))
-	req.Header.Set("Authorization", "Basic "+credentials)
-	req.Header.Set("Content-Type", mpWriter.FormDataContentType())
-	req.ContentLength = int64(body.Len())
-
-	resp, err := c.client.Do(req)
-	if err != nil {
-		return fmt.Errorf("request failed: %w", err)
-	}
-	defer resp.Body.Close()
-
-	rawBytes, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return fmt.Errorf("failed to read response body: %w", err)
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("unexpected status %s: %s", resp.Status, string(rawBytes))
-	}
-
-	if err := isErrorResponse(rawBytes); err != nil {
-		return err
-	}
-
-	return nil
-}
 
 type GroceryList struct {
 	UID            string `json:"uid"`
@@ -824,8 +764,8 @@ func (c *Client) ListGroceries(ctx context.Context) (*GroceryResponse, error) {
 	return &groceryResp, nil
 }
 
-// SaveMealPlan saves a meal plan entry to Paprika API using V1 API.
-// The V2 sync endpoints don't support meal writes.
+// SaveMealPlan saves a meal plan entry to the Paprika API.
+// Meals use the bulk array endpoint POST /api/v2/sync/meals/ (not the per-item pattern recipes use).
 func (c *Client) SaveMealPlan(ctx context.Context, meal MealPlan) (*MealPlan, error) {
 	if meal.UID == "" {
 		meal.UID = strings.ToUpper(uuid.New().String())
@@ -834,12 +774,7 @@ func (c *Client) SaveMealPlan(ctx context.Context, meal MealPlan) (*MealPlan, er
 
 	c.logger.Info("Saving meal", "uid", meal.UID, "name", meal.Name, "date", meal.Date, "type", meal.Type)
 
-	data, err := json.Marshal([]MealPlan{meal})
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal meal: %w", err)
-	}
-
-	if err := c.postV1(ctx, "https://paprikaapp.com/api/v1/sync/meals/", data); err != nil {
+	if err := c.postV2(ctx, "https://www.paprikaapp.com/api/v2/sync/meals/", []MealPlan{meal}); err != nil {
 		return nil, fmt.Errorf("failed to save meal: %w", err)
 	}
 
@@ -851,12 +786,8 @@ func (c *Client) SaveMealPlan(ctx context.Context, meal MealPlan) (*MealPlan, er
 func (c *Client) DeleteMealPlan(ctx context.Context, uid string) error {
 	c.logger.Info("Soft-deleting meal", "uid", uid)
 
-	data, err := json.Marshal([]MealPlan{{UID: uid, Deleted: true}})
-	if err != nil {
-		return fmt.Errorf("failed to marshal meal deletion: %w", err)
-	}
-
-	if err := c.postV1(ctx, "https://paprikaapp.com/api/v1/sync/meals/", data); err != nil {
+	meal := MealPlan{UID: uid, Deleted: true}
+	if err := c.postV2(ctx, "https://www.paprikaapp.com/api/v2/sync/meals/", []MealPlan{meal}); err != nil {
 		return fmt.Errorf("failed to delete meal: %w", err)
 	}
 
@@ -864,8 +795,8 @@ func (c *Client) DeleteMealPlan(ctx context.Context, uid string) error {
 	return nil
 }
 
-// SaveGroceryItem saves a grocery item to Paprika API using V1 API.
-// The V2 sync endpoints don't support grocery writes.
+// SaveGroceryItem saves a grocery item to the Paprika API.
+// Groceries use the bulk array endpoint POST /api/v2/sync/groceries/ (not the per-item pattern recipes use).
 func (c *Client) SaveGroceryItem(ctx context.Context, item GroceryItem) (*GroceryItem, error) {
 	if item.UID == "" {
 		item.UID = strings.ToUpper(uuid.New().String())
@@ -876,12 +807,7 @@ func (c *Client) SaveGroceryItem(ctx context.Context, item GroceryItem) (*Grocer
 
 	c.logger.Info("Saving grocery item", "uid", item.UID, "ingredient", item.Ingredient, "aisle", item.Aisle)
 
-	data, err := json.Marshal([]GroceryItem{item})
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal grocery item: %w", err)
-	}
-
-	if err := c.postV1(ctx, "https://paprikaapp.com/api/v1/sync/groceries/", data); err != nil {
+	if err := c.postV2(ctx, "https://www.paprikaapp.com/api/v2/sync/groceries/", []GroceryItem{item}); err != nil {
 		return nil, fmt.Errorf("failed to save grocery item: %w", err)
 	}
 
@@ -893,12 +819,8 @@ func (c *Client) SaveGroceryItem(ctx context.Context, item GroceryItem) (*Grocer
 func (c *Client) DeleteGroceryItem(ctx context.Context, uid string) error {
 	c.logger.Info("Soft-deleting grocery item", "uid", uid)
 
-	data, err := json.Marshal([]GroceryItem{{UID: uid, Deleted: true}})
-	if err != nil {
-		return fmt.Errorf("failed to marshal grocery item deletion: %w", err)
-	}
-
-	if err := c.postV1(ctx, "https://paprikaapp.com/api/v1/sync/groceries/", data); err != nil {
+	item := GroceryItem{UID: uid, Deleted: true}
+	if err := c.postV2(ctx, "https://www.paprikaapp.com/api/v2/sync/groceries/", []GroceryItem{item}); err != nil {
 		return fmt.Errorf("failed to delete grocery item: %w", err)
 	}
 

--- a/internal/paprika/client_test.go
+++ b/internal/paprika/client_test.go
@@ -2,7 +2,6 @@ package paprika_test
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 	"testing"
@@ -13,12 +12,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestClient(t *testing.T) {
+func newTestClient(t *testing.T) *paprika.Client {
+	t.Helper()
 	username := os.Getenv("PAPRIKA_USERNAME")
 	password := os.Getenv("PAPRIKA_PASSWORD")
+	if username == "" || password == "" {
+		t.Skip("PAPRIKA_USERNAME and PAPRIKA_PASSWORD must be set")
+	}
 	client, err := paprika.NewClient(username, password, "dev", nil)
 	require.NoError(t, err)
-	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	return client
+}
+
+func TestClient(t *testing.T) {
+	client := newTestClient(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	testRecipe := paprika.Recipe{
@@ -70,16 +78,184 @@ func TestClient(t *testing.T) {
 	require.NoError(t, err)
 	t.Logf("Deleted recipe: %s", recipe.Name)
 
+	// Verify the test recipe appears in the recipe list
 	recipes, err := client.ListRecipes(ctx)
 	require.NoError(t, err)
 
-	for _, recipe := range recipes.Result {
-		r, err := client.GetRecipe(ctx, recipe.UID)
-		require.NoError(t, err)
-
-		t.Logf("Recipe: %s - %s", r.Name, r.Created)
-		if _, err := json.Marshal(r); err != nil {
-			t.Logf("Failed to marshal recipe: %s", err)
+	found := false
+	for _, r := range recipes.Result {
+		if r.UID == uid {
+			found = true
+			break
 		}
 	}
+	assert.True(t, found, "test recipe should appear in recipe list (even after soft delete)")
+
+	// Verify the trashed recipe is marked as in_trash
+	trashedRecipe, err := client.GetRecipe(ctx, uid)
+	require.NoError(t, err)
+	assert.True(t, trashedRecipe.InTrash, "deleted recipe should be in trash")
+}
+
+func TestListGroceryLists(t *testing.T) {
+	client := newTestClient(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	resp, err := client.ListGroceryLists(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.NotEmpty(t, resp.Result, "account should have at least one grocery list")
+
+	// Every account should have a default list
+	hasDefault := false
+	for _, list := range resp.Result {
+		t.Logf("  List: %q  UID: %s  Default: %v", list.Name, list.UID, list.IsDefault)
+		assert.NotEmpty(t, list.UID)
+		assert.NotEmpty(t, list.Name)
+		if list.IsDefault {
+			hasDefault = true
+		}
+	}
+	assert.True(t, hasDefault, "should have a default grocery list")
+}
+
+func TestMealPlan(t *testing.T) {
+	client := newTestClient(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Create a meal plan entry
+	testMeal := paprika.MealPlan{
+		Date:      "2099-01-01 00:00:00",
+		Name:      fmt.Sprintf("Test Meal - %d", time.Now().Unix()),
+		Type:      paprika.MealTypeDinner,
+		OrderFlag: 0,
+	}
+	savedMeal, err := client.SaveMealPlan(ctx, testMeal)
+	require.NoError(t, err)
+	assert.NotEmpty(t, savedMeal.UID)
+	assert.Equal(t, testMeal.Name, savedMeal.Name)
+	assert.Equal(t, testMeal.Date, savedMeal.Date)
+	assert.Equal(t, testMeal.Type, savedMeal.Type)
+	assert.False(t, savedMeal.Deleted)
+	t.Logf("Created meal: %+v", savedMeal)
+
+	// List meal plan and verify our entry is present
+	mealPlanResp, err := client.ListMealPlan(ctx)
+	require.NoError(t, err)
+	assert.NotNil(t, mealPlanResp)
+
+	found := false
+	for _, meal := range mealPlanResp.Result {
+		if meal.UID == savedMeal.UID {
+			found = true
+			assert.Equal(t, testMeal.Name, meal.Name)
+			break
+		}
+	}
+	assert.True(t, found, "saved meal should appear in meal plan list")
+
+	// Delete the meal plan entry
+	err = client.DeleteMealPlan(ctx, savedMeal.UID)
+	require.NoError(t, err)
+	t.Logf("Deleted meal: %s", savedMeal.UID)
+}
+
+func TestGroceries(t *testing.T) {
+	client := newTestClient(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Add a grocery item (default list)
+	testItem := paprika.GroceryItem{
+		Ingredient: fmt.Sprintf("Test Ingredient - %d", time.Now().Unix()),
+		Aisle:      "Produce",
+		Quantity:   "2 lbs",
+		Recipe:     "Test Recipe",
+	}
+	savedItem, err := client.SaveGroceryItem(ctx, testItem)
+	require.NoError(t, err)
+	assert.NotEmpty(t, savedItem.UID)
+	assert.Equal(t, testItem.Ingredient, savedItem.Ingredient)
+	assert.Equal(t, testItem.Aisle, savedItem.Aisle)
+	assert.Equal(t, testItem.Quantity, savedItem.Quantity)
+	assert.Equal(t, testItem.Ingredient, savedItem.Name, "Name should default to Ingredient")
+	t.Logf("Created grocery item (default list): %+v", savedItem)
+
+	// List groceries and verify our item is present
+	groceryResp, err := client.ListGroceries(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, groceryResp)
+
+	found := false
+	for _, item := range groceryResp.Result {
+		if item.UID == savedItem.UID {
+			found = true
+			assert.Equal(t, testItem.Ingredient, item.Ingredient)
+			t.Logf("Item added without ListUID has ListUID=%q from API", item.ListUID)
+			break
+		}
+	}
+	assert.True(t, found, "saved grocery item should appear in grocery list")
+
+	// Clean up default list item
+	err = client.DeleteGroceryItem(ctx, savedItem.UID)
+	require.NoError(t, err)
+	t.Logf("Deleted grocery item: %s", savedItem.UID)
+}
+
+func TestGroceryItemOnSpecificList(t *testing.T) {
+	client := newTestClient(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// First, get available grocery lists
+	listsResp, err := client.ListGroceryLists(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, listsResp.Result, "need at least one grocery list")
+
+	// Pick a non-default list if available, otherwise use the first one
+	targetList := listsResp.Result[0]
+	for _, list := range listsResp.Result {
+		if !list.IsDefault && !list.Deleted {
+			targetList = list
+			break
+		}
+	}
+	t.Logf("Adding item to list: %q (UID: %s)", targetList.Name, targetList.UID)
+
+	// Add a grocery item to the specific list
+	testItem := paprika.GroceryItem{
+		Ingredient: fmt.Sprintf("Test ListItem - %d", time.Now().Unix()),
+		Aisle:      "Dairy",
+		Quantity:   "1 gallon",
+		ListUID:    targetList.UID,
+	}
+	savedItem, err := client.SaveGroceryItem(ctx, testItem)
+	require.NoError(t, err)
+	assert.NotEmpty(t, savedItem.UID)
+	assert.Equal(t, targetList.UID, savedItem.ListUID, "item should be on the target list")
+	t.Logf("Created grocery item on list %q: %+v", targetList.Name, savedItem)
+
+	// List all groceries and verify our item has the correct list_uid
+	groceryResp, err := client.ListGroceries(ctx)
+	require.NoError(t, err)
+
+	found := false
+	for _, item := range groceryResp.Result {
+		if item.UID == savedItem.UID {
+			found = true
+			assert.Equal(t, testItem.Ingredient, item.Ingredient)
+			assert.Equal(t, targetList.UID, item.ListUID, "item should belong to target list")
+			t.Logf("Verified item on list: ListUID=%s", item.ListUID)
+			break
+		}
+	}
+	assert.True(t, found, "saved grocery item should appear in grocery list")
+
+	// Clean up
+	err = client.DeleteGroceryItem(ctx, savedItem.UID)
+	require.NoError(t, err)
+	t.Logf("Deleted grocery item: %s", savedItem.UID)
 }


### PR DESCRIPTION
## Summary
- Switched meal and grocery sync from V1 per-item endpoints to V2 bulk array endpoints
- Fixes 401 errors on `POST /api/v1/sync/meals/` and `/api/v1/sync/groceries/`
- Uses `www.paprikaapp.com` instead of `paprikaapp.com` (may have been a factor in auth failures)
- Removes `postV1` method entirely — all writes now use the gzip+multipart+Bearer pattern via `postV2`

## Context
Discovered while integrating Paprika MCP with a meal planning app. The V1 endpoints returned 401 with both Basic Auth and Bearer token. V2 bulk endpoints work consistently.

See discussion: #10 (comment by @ksletmoe confirming the fix works)

## Test plan
- [x] Tested adding individual meals via MCP
- [x] Tested adding grocery items via MCP
- [x] Verified existing recipe sync still works